### PR TITLE
Add build scripts

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -81,12 +81,21 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
+  configure:
+    runs-on: ubuntu-latest
+    outputs:
+      uid_gid: ${{ steps.get-user.outputs.uid_gid }}
+    steps:
+      - id: get-user
+        run: echo "::set-output name=uid_gid::$(id -u):$(id -g)"
+
   render-samples:
     if: github.event_name != 'release'
-    needs: build-container
+    needs: [ build-container, configure ]
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/trustedcomputinggroup/pandoc_test
+      options: --user ${{ needs.configure.outputs.uid_gid }}
     permissions:
       contents: read
 

--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -1,0 +1,14 @@
+name: Tests
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Run Tests
+        run: ./test.sh

--- a/.github/workflows/render_markdown.yml
+++ b/.github/workflows/render_markdown.yml
@@ -1,0 +1,51 @@
+on:
+  workflow_call:
+  inputs:
+    input-md:
+      description: 'The name of the Markdown file to render'
+      required: true
+    input-use-git-version:
+      description: 'True or False to use automatic git versioning of documents'
+      type: boolean
+    output-pdf:
+      description: 'The name of the rendered PDF file'
+    output-docx:
+      description: 'The name of the rendered DOCX file'
+    output-tex:
+      description: 'The name of the rendered TEX file'
+
+jobs:
+  # Set the Docker Container to the host uid/gid.
+  # https://github.com/actions/runner/issues/691
+  configure:
+    runs-on: ubuntu-latest
+    outputs:
+      uid_gid: ${{ steps.get-user.outputs.uid_gid }}
+    steps:
+      - id: get-user
+        run: echo "::set-output name=uid_gid::$(id -u):$(id -g)"
+
+  render-markdown:
+    needs: configure
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/trustedcomputinggroup/pandoc:latest
+      options: --user ${{ needs.configure.outputs.uid_gid }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Render to DOCX
+        run: ./docker_run --puppeteer $(./na.py ${{ input-use-git-version }} --gitversion) --latex=${{ inputs.output-pdf }} ${{ inputs.input-docx }}
+        shell: bash
+        if: ${{ inputs.output-pdf }}
+
+      - name: Render to PDF
+        run: ./docker_run --puppeteer $(./na.py ${{ input-use-git-version }} --gitversion) --latex=${{ inputs.output-pdf }} ${{ inputs.input-md }}
+        shell: bash
+        if: ${{ inputs.output-pdf }}
+
+      - name: Render to LaTeX
+        run: ./docker_run --puppeteer $(./na.py ${{ input-use-git-version }} --gitversion) --latex=${{ inputs.output-tex }} ${{ inputs.input-md }}
+        shell: bash
+        if: ${{ inputs.output-tex }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,8 @@ RUN tlmgr update --self && \
     textpos \
     anyfontsize \
     transparent \
-    ulem
+    ulem \
+    hardwrap
 
 RUN apk upgrade && apk add --no-cache \
     bash \

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,3 +65,7 @@ RUN cd /src && git clone https://github.com/davidar/pandiff.git
 RUN cd /src/pandiff && git checkout d1d468b2c4d81c622ff431ef718b1bf0daaa03db
 RUN cd /src/pandiff && npm install @types/node --save-dev
 RUN npm install --global /src/pandiff
+
+COPY build.sh /usr/bin/build.sh
+ENTRYPOINT ["/usr/bin/build.sh"]
+CMD ["--help"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,8 @@ RUN tlmgr update --self && \
     anyfontsize \
     transparent \
     ulem \
-    hardwrap
+    hardwrap \
+    catchfile
 
 RUN apk upgrade && apk add --no-cache \
     bash \

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,255 @@
+#!/usr/bin/env bash
+
+is_tmp="yes"	  # default to no tmp directory
+resource_dir="/"  #default to root of pandoc container buildout
+do_puppeteer="no"
+do_pdf="no"
+do_docx="no"
+do_latex="no"
+
+# Setup an EXIT handler
+on_exit() {
+	if [[ "${is_tmp}" == "yes" && -e "${build_dir}" ]]; then
+		rm -rf "${build_dir}"
+	fi
+}
+
+trap on_exit EXIT
+
+print_usage() {
+	echo "Usage:"
+	echo "$(basename "${0}") [options] [input-file]"
+	echo
+	echo "Arguments:"
+	echo "  This script takes a single markdown file input for rendering to docx/pdf/LaTex. Default is pdf."
+	echo "  The output file is the input-file basename with the file extension appended based on output format".
+	echo
+	echo "Options:"
+	echo
+	echo "Output Control"
+	echo "  --docx: enable outputing of docx Output file will be input-file.docx"
+	echo "  --pdf:  enable outputing of pdf. Output file will be input-file.pdf"
+	echo "  --latex:  enable outputing of pdf. Output file will be input-file.tex"
+	echo
+	echo "Miscellaneous"
+	echo "  --puppeteer: enable outputing of .puppeteer.json in current directory"
+	echo "  --resouredir: Set the resource directory, defaults to root for pandoc containers"
+	echo "  --notmp: Do not use a tempory directory for processing steps, instead create a directory called \"build\" in CWD"
+}
+
+
+options=$(getopt --longoptions=help,puppeteer,pdf,latex,docx,notmp,resouredir: --options="" -- "$@")
+if [ $? -ne 0 ]; then
+	echo "Incorrect options provided"
+	print_usage
+	exit 1
+fi
+
+eval set -- "${options}"
+while true; do
+	case "$1" in
+	--puppeteer)
+		do_puppeteer="yes"
+		shift
+		;;
+	--docx)
+		do_docx="yes"
+		shift
+		;;
+	--latex)
+		do_latex="yes"
+		shift
+		;;
+	--pdf)
+		do_pdf="yes"
+		shift
+		;;
+	--notmp)
+		is_tmp="no"
+		shift
+		;;
+	--resouredir)
+		resource_dir="${2}"
+		shift 2
+		;;
+	--help)
+		print_usage
+		shift
+		exit 0
+		;;
+	--)
+		shift
+		break
+		;;
+	esac
+	shift
+done
+
+shift "$(( OPTIND - 1 ))"
+
+# argcount check
+if [ $# -ne 1 ]; then
+	>&2 echo "Expected 1 markdown input file for processing, got: $*"
+	print_usage
+	exit 1
+fi
+
+# input file check
+input_file=$1
+if [ ! -e "${input_file}" ]; then
+   >&2 echo "${input_file} does not exist, exiting..."
+   exit 1
+fi
+
+# Set up the output directory, either tmp or build in pwd.
+if [ "${is_tmp}" == "yes" ]; then
+	build_dir="$(mktemp -d)"
+else
+	build_dir="$(pwd)/build"
+	mkdir -p "${build_dir}"
+fi
+
+# default to pdf enabled
+if [ "${do_pdf}${do_latex}${do_docx}" == "nonono" ]; then
+	do_pdf="yes"
+fi
+
+# Get the default browser
+if ! browser=$(command -v "chromium-browser"); then
+	if ! browser=$(command -v "google-chrome"); then
+		browser="none"
+	fi
+fi
+
+echo "Starting Build with"
+echo "puppeteer: ${do_puppeteer}"
+echo "docx: ${do_docx}"
+echo "pdf: ${do_pdf}"
+echo "latex: ${do_latex}"
+echo "use tmp: ${is_tmp}"
+echo "resource dir: ${resource_dir}"
+echo "build dir: ${build_dir}"
+echo "browser: ${browser}"
+
+if [ "${do_puppeteer}" == "yes" ]; then
+	if [ "${browser}" == "none" ]; then
+		>&2 echo "No Browser found, looked for chromium-browser and google-chrome"
+		exit 1
+	fi
+
+	# There are some configuration dependencies required for Mermaid.
+	# They have to be in the current directory.
+	cat <<- EOF > ./.puppeteer.json
+	{
+		"executablePath": "$browser",
+		"args": [
+			"--no-sandbox",
+			"--disable-setuid-sandbox"
+		]
+	}
+	EOF
+fi
+
+# Transform 1
+# GitHub Mermaid doesn't recognize the full ```{.mermaid ...} attributes-form
+# Pandoc doesn't recognized mixed ```mermaid {...} form
+# Hack: use sed to transform the former to the latter so everyone is happy
+sed 's/```mermaid *{/```{.mermaid /g' "${input_file}" > "${build_dir}/${input_file}.1"
+
+
+# Transform 2
+# \newpage is rendered as the string "\newpage" in GitHub markdown.
+# Transform horizontal rules into \newpages.
+# Exception: the YAML front matter of the document, so undo the instance on the first line.
+sed 's/^---$/\\newpage/g;1s/\\newpage/---/g' "${build_dir}/${input_file}.1" > "${build_dir}/${input_file}.2"
+
+# Transform 3
+# Transform sections before the table of contents into addsec, which does not number them.
+# While we're doing this, transform the case to all-caps.
+sed '0,/\\tableofcontents/s/^# \(.*\)/\\addsec\{\U\1\}/g' "${build_dir}/${input_file}.2" > "${build_dir}/${input_file}.3"
+
+# Grab the date from the front matter and generate the full date and year.
+DATE="$(grep date: "${input_file}" | head -n 1 | cut -d ' ' -f 2)"
+YEAR="$(date --date="${DATE}" +%Y)"
+DATE_ENGLISH="$(date --date="${DATE}" "+%B %-d, %Y")"
+
+# Run Pandoc
+export MERMAID_FILTER_THEME="forest"
+export MERMAID_FILTER_FORMAT="pdf"
+
+# Generate the pdf
+pdf_output="$(basename "${input_file}")".pdf
+if [ "${do_pdf}" = "yes" ]; then
+	pandoc \
+		--embed-resources \
+		--standalone \
+		--template=eisvogel.latex \
+		--filter=mermaid-filter \
+		--filter=pandoc-crossref \
+		--resource-path=.:/resources \
+		--data-dir=/resources \
+		--top-level-division=section \
+		--variable=block-headings \
+		--variable=numbersections \
+		--variable=table-use-row-colors \
+		--metadata=date-english:"${DATE_ENGLISH}" \
+		--metadata=year:"${YEAR}" \
+		--metadata=titlepage:true \
+		--metadata=titlepage-background:/resources/img/cover.png \
+		--metadata=logo:/resources/img/tcg.png \
+		--metadata=titlepage-rule-height:0 \
+		--metadata=colorlinks:true \
+		--metadata=contact:admin@trustedcomputinggroup.org \
+		--from=markdown+implicit_figures+table_captions \
+		--to=pdf \
+		"${build_dir}/${input_file}.3" \
+		--output="${pdf_output}"
+fi
+
+# Generate the LaTeX output
+latex_output="$(basename "${input_file}")".tex
+if [ "${do_latex}" = "yes" ]; then
+	pandoc \
+		--embed-resources \
+		--standalone \
+		--template=eisvogel.latex \
+		--filter=mermaid-filter \
+		--filter=pandoc-crossref \
+		--resource-path=.:/resources \
+		--data-dir=/resources \
+		--top-level-division=section \
+		--variable=block-headings \
+		--variable=numbersections \
+		--variable=table-use-row-colors \
+		--metadata=date-english:"${DATE_ENGLISH}" \
+		--metadata=year:"${YEAR}" \
+		--metadata=titlepage:true \
+		--metadata=titlepage-background:/resources/img/cover.png \
+		--metadata=logo:/resources/img/tcg.png \
+		--metadata=titlepage-rule-height:0 \
+		--metadata=colorlinks:true \
+		--metadata=contact:admin@trustedcomputinggroup.org \
+		--from=markdown+implicit_figures+table_captions \
+		--to=latex \
+		"${build_dir}/${input_file}.3" \
+		--output="${latex_output}"
+fi
+
+# Generate the docx output
+docx_output="$(basename "${input_file}")".docx
+if [ "${do_docx}" = "yes" ]; then
+	pandoc \
+		--embed-resources \
+		--standalone \
+		--filter=/resources/filters/info.py \
+		--filter=mermaid-filter \
+		--filter=pandoc-crossref \
+		--resource-path=.:/resources \
+		--data-dir=/resources \
+		--from=markdown+implicit_figures+table_captions \
+		--reference-doc=/resources/templates/tcg_template.docx \
+		--to=docx
+		"${build_dir}/${input_file}.3" \
+		--output="${docx_output}"
+fi
+

--- a/build.sh
+++ b/build.sh
@@ -3,9 +3,9 @@
 is_tmp="yes"	  # default to no tmp directory
 resource_dir="/"  #default to root of pandoc container buildout
 do_puppeteer="no"
-do_pdf="no"
-do_docx="no"
-do_latex="no"
+pdf_output=""
+docx_output=""
+latex_output=""
 
 # Setup an EXIT handler
 on_exit() {
@@ -21,25 +21,23 @@ print_usage() {
 	echo "$(basename "${0}") [options] [input-file]"
 	echo
 	echo "Arguments:"
-	echo "  This script takes a single markdown file input for rendering to docx/pdf/LaTex. Default is pdf."
-	echo "  The output file is the input-file basename with the file extension appended based on output format".
+	echo "  This script takes a single markdown file input for rendering to docx/pdf/LaTex."
 	echo
 	echo "Options:"
 	echo
 	echo "Output Control"
-	echo "  --docx: enable outputing of docx Output file will be input-file.docx"
-	echo "  --pdf:  enable outputing of pdf. Output file will be input-file.pdf"
-	echo "  --latex:  enable outputing of pdf. Output file will be input-file.tex"
+	echo "  --docx=output: enable outputing of docx and specify the output file name."
+	echo "  --pdf=output: enable outputing of pdf and specify the output file name."
+	echo "  --latex=output: enable outputing of latex and specify the output file name."
 	echo
 	echo "Miscellaneous"
-	echo "  --puppeteer: enable outputing of .puppeteer.json in current directory"
-	echo "  --resouredir: Set the resource directory, defaults to root for pandoc containers"
+	echo "  --puppeteer: enable outputing of .puppeteer.json in current directory. This is needed for running in sandboxes eg docker containers."
+	echo "  --resouredir=dir: Set the resource directory, defaults to root for pandoc containers"
 	echo "  --notmp: Do not use a tempory directory for processing steps, instead create a directory called \"build\" in CWD"
 }
 
 
-options=$(getopt --longoptions=help,puppeteer,pdf,latex,docx,notmp,resouredir: --options="" -- "$@")
-if [ $? -ne 0 ]; then
+if ! options=$(getopt --longoptions=help,puppeteer,pdf:,latex:,docx:,notmp,resouredir: --options="" -- "$@"); then
 	echo "Incorrect options provided"
 	print_usage
 	exit 1
@@ -50,19 +48,19 @@ while true; do
 	case "$1" in
 	--puppeteer)
 		do_puppeteer="yes"
-		shift
+		shift 2
 		;;
 	--docx)
-		do_docx="yes"
-		shift
+		docx_output="${2}"
+		shift 2
 		;;
 	--latex)
-		do_latex="yes"
-		shift
+		latex_output="${2}"
+		shift 2
 		;;
 	--pdf)
-		do_pdf="yes"
-		shift
+		pdf_output="${2}"
+		shift 2
 		;;
 	--notmp)
 		is_tmp="no"
@@ -82,7 +80,6 @@ while true; do
 		break
 		;;
 	esac
-	shift
 done
 
 shift "$(( OPTIND - 1 ))"
@@ -101,17 +98,18 @@ if [ ! -e "${input_file}" ]; then
    exit 1
 fi
 
+if [ -z "${pdf_output}${latex_output}${docx_output}" ]; then
+	>&2 echo "Expected --pdf, --docx or --latex option"
+	print_usage
+	exit 1
+fi
+
 # Set up the output directory, either tmp or build in pwd.
 if [ "${is_tmp}" == "yes" ]; then
 	build_dir="$(mktemp -d)"
 else
 	build_dir="$(pwd)/build"
 	mkdir -p "${build_dir}"
-fi
-
-# default to pdf enabled
-if [ "${do_pdf}${do_latex}${do_docx}" == "nonono" ]; then
-	do_pdf="yes"
 fi
 
 # Get the default browser
@@ -122,10 +120,11 @@ if ! browser=$(command -v "chromium-browser"); then
 fi
 
 echo "Starting Build with"
+echo "file: ${input_file}"
 echo "puppeteer: ${do_puppeteer}"
-echo "docx: ${do_docx}"
-echo "pdf: ${do_pdf}"
-echo "latex: ${do_latex}"
+echo "docx: ${docx_output:-none}"
+echo "pdf: ${pdf_output:-none}"
+echo "latex: ${latex_ouput:-none}"
 echo "use tmp: ${is_tmp}"
 echo "resource dir: ${resource_dir}"
 echo "build dir: ${build_dir}"
@@ -178,8 +177,7 @@ export MERMAID_FILTER_THEME="forest"
 export MERMAID_FILTER_FORMAT="pdf"
 
 # Generate the pdf
-pdf_output="$(basename "${input_file}")".pdf
-if [ "${do_pdf}" = "yes" ]; then
+if [ -n "${pdf_output}" ]; then
 	pandoc \
 		--embed-resources \
 		--standalone \
@@ -207,8 +205,7 @@ if [ "${do_pdf}" = "yes" ]; then
 fi
 
 # Generate the LaTeX output
-latex_output="$(basename "${input_file}")".tex
-if [ "${do_latex}" = "yes" ]; then
+if [ -n "${latex_output}" ]; then
 	pandoc \
 		--embed-resources \
 		--standalone \
@@ -236,8 +233,7 @@ if [ "${do_latex}" = "yes" ]; then
 fi
 
 # Generate the docx output
-docx_output="$(basename "${input_file}")".docx
-if [ "${do_docx}" = "yes" ]; then
+if [ -n "${docx_output}" ]; then
 	pandoc \
 		--embed-resources \
 		--standalone \
@@ -248,8 +244,15 @@ if [ "${do_docx}" = "yes" ]; then
 		--data-dir=/resources \
 		--from=markdown+implicit_figures+table_captions \
 		--reference-doc=/resources/templates/tcg_template.docx \
-		--to=docx
+		--to=docx \
 		"${build_dir}/${input_file}.3" \
 		--output="${docx_output}"
 fi
+if [ $? -ne 0 ]; then
+	exit 1
+fi
 
+# on success remove this output
+rm -f mermaid-filter.err
+
+exit 0

--- a/build.sh
+++ b/build.sh
@@ -235,6 +235,7 @@ export MERMAID_FILTER_FORMAT="pdf"
 
 # Generate the pdf
 if [ -n "${pdf_output}" ]; then
+	echo "Generating PDF Output"
 	pandoc \
 		--embed-resources \
 		--standalone \
@@ -260,10 +261,12 @@ if [ -n "${pdf_output}" ]; then
 		--to=pdf \
 		"${build_dir}/${input_file}.3" \
 		--output="${pdf_output}"
+	echo "PDF Output Generated to file: ${pdf_output}"
 fi
 
 # Generate the LaTeX output
 if [ -n "${latex_output}" ]; then
+	echo "Generating LaTeX Output"
 	pandoc \
 		--embed-resources \
 		--standalone \
@@ -289,10 +292,12 @@ if [ -n "${latex_output}" ]; then
 		--to=latex \
 		"${build_dir}/${input_file}.3" \
 		--output="${latex_output}"
+	echo "LaTeX Output Generated to file: ${latex_output}"
 fi
 
 # Generate the docx output
 if [ -n "${docx_output}" ]; then
+	echo "Generating DOCX Output"
 	pandoc \
 		--embed-resources \
 		--standalone \
@@ -307,6 +312,7 @@ if [ -n "${docx_output}" ]; then
 		--to=docx \
 		"${build_dir}/${input_file}.3" \
 		--output="${docx_output}"
+	echo "DOCX Output Generated to file: ${docx_output}"
 fi
 if [ $? -ne 0 ]; then
 	exit 1

--- a/docker_run
+++ b/docker_run
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+docker_image=${DOCKER_IMAGE:-"ghcr.io/trustedcomputinggroup/pandoc:latest"}
+
+print_usage() {
+	echo "Usage:"
+	echo "$(basename "${0}") [options] [build.sh arguments]"
+	echo
+	echo "Arguments:"
+	echo "  Arguments to this script are passed as parameters to build.sh inside of the docker conatiner"
+	echo
+	echo "Environment:"
+	echo
+	echo "DOCKER_IMAGE: set this env variable to the docker image to run, defaults to ${docker_image}"
+	echo
+	echo "Options:"
+	echo
+	echo "Miscellaneous"
+	echo "  --help: output this message"
+}
+
+# hand process options as we want all options to go to docker run command except ones we know
+if test "${1}" == "--help"; then
+	print_usage
+	exit 0
+fi
+
+echo "Launching Container: ${docker_image}"
+docker run -v "$(pwd):/workspace" -it --user="$(id -u):$(id -g)" -w/workspace "${docker_image}" "$@"

--- a/docker_run
+++ b/docker_run
@@ -26,4 +26,4 @@ if test "${1}" == "--help"; then
 fi
 
 echo "Launching Container: ${docker_image}"
-docker run -v "$(pwd):/workspace" -it --user="$(id -u):$(id -g)" -w/workspace "${docker_image}" "$@"
+docker run -v "$(pwd):/workspace" --user="$(id -u):$(id -g)" -w/workspace "${docker_image}" "$@"

--- a/na.py
+++ b/na.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+
+# Normalize a YAML true/false/yes/no to enable or disable an argument.
+
+import sys
+import yaml
+
+
+def main():
+
+    if len(sys.argv) != 3:
+        sys.exit(f"Expected 2 arguments, got: {sys.argv[1:]}")
+
+    y = yaml.safe_load(f"value: {sys.argv[1]}")
+    if y["value"]:
+        sys.stdout.write(sys.argv[2])
+
+
+if __name__ == "__main__":
+    main()

--- a/sample3.md
+++ b/sample3.md
@@ -1,0 +1,153 @@
+---
+title: "Important TCG Document"
+date-english: August 11, 2022
+date: 8/11/2022
+year: 2022
+type: SPECIFICATION
+status: PUBLISHED
+template: bluetop
+...
+
+\newpage
+
+# Disclaimers, Notices, and License Terms
+
+THIS SPECIFICATION IS PROVIDED “AS IS” WITH NO WARRANTIES WHATSOEVER, INCLUDING
+ANY WARRANTY OF MERCHANTABILITY, NONINFRINGEMENT, FITNESS FOR ANY PARTICULAR
+PURPOSE, OR ANY WARRANTY OTHERWISE ARISING OUT OF ANY PROPOSAL, SPECIFICATION OR
+SAMPLE.
+
+Without limitation, TCG disclaims all liability, including liability for
+infringement of any proprietary rights, relating to use of information in this
+specification and to the implementation of this specification, and TCG disclaims
+all liability for cost of procurement of substitute goods or services, lost
+profits, loss of use, loss of data or any incidental, consequential, direct,
+indirect, or special damages, whether under contract, tort, warranty or
+otherwise, arising in any way out of use or reliance upon this specification or
+any information herein. This document is copyrighted by Trusted Computing Group
+(TCG), and no license, express or implied, is granted herein other than as
+follows: You may not copy or reproduce the document or distribute it to others
+without written permission from TCG, except that you may freely do so for the
+purposes of (a) examining or implementing TCG specifications or (b) developing,
+testing, or promoting information technology standards and best practices, so long
+as you distribute the document with these disclaimers, notices, and license terms.
+Contact the Trusted Computing Group at www.trustedcomputinggroup.org for
+information on specification licensing through membership agreements. Any marks
+and brands contained herein are the property of their respective owners.
+
+---
+
+# Change History
+
+| **Revision** | **Date**   | **Description** |
+| ------------ | ---------- | --------------- |
+| 0.2/17       | 2022/08/10 | Initial draft   |
+| 0.2/18       | 2022/08/10 | Add page breaks |
+
+---
+
+\tableofcontents
+\listoftables
+\listoffigures
+
+---
+
+# Introduction
+
+Published specification with a list of figures.
+
+## Details
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis
+nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu
+fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
+culpa qui officia deserunt mollit anim id est laborum.
+
+## Figures
+
+### Computer
+
+To include an image in the list of figures, use the "#fig" attribute.
+
+![a computer](computer.jpg){#fig:computer}
+
+### Sequence
+
+To include a Mermaid diagram in the list of figures, use the "caption" option.
+
+See the [mermaid-filter documentation](https://github.com/raghur/mermaid-filter#options)
+for a list of all the options.
+
+```{.mermaid caption="startup"}
+sequenceDiagram
+Host->>TPM: TPM2_Startup
+loop Measurements
+    Host->>TPM: TPM2_PCR_Extend
+end
+Host->>TPM: TPM2_Quote
+TPM->>Host: <quoted PCRs>
+```
+
+### Flowchart
+
+```{.mermaid caption="abcd"}
+graph TD;
+    A-->B;
+    A-->C;
+    B-->D;
+    C-->D;
+```
+
+### Mandatory Algorithms
+
+Table: List of Mandatory Algorithms
+
+| **Algorithm ID** | **M/R/O/D** | **Comments**                                  |
+| ---------------- | ----------- | --------------------------------------------- |
+| TPM_ALG_ECC      | M           | Support for 256 and 384-bit keys is required. |
+| TPM_ALG_ECDSA    | M           |
+| TPM_ALG_ECDH     | M           |
+| TPM_ALG_ECDAA    | O           |
+| TPM_ALG_RSA      | O           |
+| TPM_ALG_RSAES    | O           |
+| TPM_ALG_RSAPSS   | O           |
+| TPM_ALG_RSAOAEP  | O           |
+| TPM_ALG_AES      | M           |
+| TPM_ALG_SHA256   | M           |
+| TPM_ALG_SHA384   | M           |
+| TPM_ALG_SHA512   | O           |
+| TPM_ALG_HMAC     | M           |
+| TPM_ALG_SHA3_256 | O           |
+| TPM_ALG_SHA3_384 | O           |
+| TPM_ALG_SHA3_512 | O           |
+| TPM_ALG_NULL     | M           |
+
+### Mandatory Curves
+
+Table: List of Mandatory Curves
+
+| **Curve Identifier** | **M/R/O/D** | **Comments** |
+| -------------------- | ----------- | ------------ |
+| TPM_ECC_NIST_P256    | M           |
+| TPM_ECC_NIST_P384    | M           |
+
+## Code
+
+```c++
+#include <string>
+
+int main() {
+    std::string result = "Trusted Computing Group";
+    return 1;
+}
+```
+
+## Another Table
+
+Table: Fantastic Table
+
+| **Column 1** | **Column 2** | **Column 3** |
+| ------------ | ------------ | ------------ |
+| AAAAAAAA     | BBBBBBBB     | CCCCCCCC     |

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -e
+
+hash="$(docker build . -q -f Dockerfile)"
+
+DOCKER_IMAGE="${hash}" ./docker_run --puppeteer --gitversion --latex=sample1.tex --pdf=sample1.pdf --docx=sample1.docx sample1.md

--- a/test.sh
+++ b/test.sh
@@ -2,6 +2,6 @@
 
 set -e
 
-hash="$(docker build . -q -f Dockerfile)"
+docker build . --tag=test -f Dockerfile
 
-DOCKER_IMAGE="${hash}" ./docker_run --puppeteer --gitversion --latex=sample1.tex --pdf=sample1.pdf --docx=sample1.docx sample1.md
+DOCKER_IMAGE="test" ./docker_run --puppeteer --gitversion --latex=sample1.tex --pdf=sample1.pdf --docx=sample1.docx sample1.md


### PR DESCRIPTION
Add build scripts to make building documentation from source markdown simpler for end users.

- This adds a script build.sh and defines the default entry point as build.sh.
- This also adds a docker_run command to make running the container easier for end users.
- Adds git versioning support from git-describe. Fixes #31 