### PR TITLE
Add build scripts v2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,8 @@ RUN tlmgr update --self && \
     textpos \
     anyfontsize \
     transparent \
-    ulem
+    ulem \
+    hardwrap
 
 RUN apk upgrade && apk add --no-cache \
     bash \

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,3 +65,7 @@ RUN cd /src && git clone https://github.com/davidar/pandiff.git
 RUN cd /src/pandiff && git checkout d1d468b2c4d81c622ff431ef718b1bf0daaa03db
 RUN cd /src/pandiff && npm install @types/node --save-dev
 RUN npm install --global /src/pandiff
+
+COPY build.sh /usr/bin/build.sh
+ENTRYPOINT ["/usr/bin/build.sh"]
+CMD ["--help"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,6 +66,10 @@ RUN cd /src/pandiff && git checkout d1d468b2c4d81c622ff431ef718b1bf0daaa03db
 RUN cd /src/pandiff && npm install @types/node --save-dev
 RUN npm install --global /src/pandiff
 
+# mktexpk gets executed and needs a home dir, build one
+RUN mkdir -m 0777 /home/user
+ENV HOME="/home/user"
+
 COPY build.sh /usr/bin/build.sh
 ENTRYPOINT ["/usr/bin/build.sh"]
 CMD ["--help"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,8 @@ RUN tlmgr update --self && \
     anyfontsize \
     transparent \
     ulem \
-    hardwrap
+    hardwrap \
+    catchfile
 
 RUN apk upgrade && apk add --no-cache \
     bash \

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,255 @@
+#!/usr/bin/env bash
+
+is_tmp="yes"	  # default to no tmp directory
+resource_dir="/"  #default to root of pandoc container buildout
+do_puppeteer="no"
+do_pdf="no"
+do_docx="no"
+do_latex="no"
+
+# Setup an EXIT handler
+on_exit() {
+	if [[ "${is_tmp}" == "yes" && -e "${build_dir}" ]]; then
+		rm -rf "${build_dir}"
+	fi
+}
+
+trap on_exit EXIT
+
+print_usage() {
+	echo "Usage:"
+	echo "$(basename "${0}") [options] [input-file]"
+	echo
+	echo "Arguments:"
+	echo "  This script takes a single markdown file input for rendering to docx/pdf/LaTex. Default is pdf."
+	echo "  The output file is the input-file basename with the file extension appended based on output format".
+	echo
+	echo "Options:"
+	echo
+	echo "Output Control"
+	echo "  --docx: enable outputing of docx Output file will be input-file.docx"
+	echo "  --pdf:  enable outputing of pdf. Output file will be input-file.pdf"
+	echo "  --latex:  enable outputing of pdf. Output file will be input-file.tex"
+	echo
+	echo "Miscellaneous"
+	echo "  --puppeteer: enable outputing of .puppeteer.json in current directory"
+	echo "  --resouredir: Set the resource directory, defaults to root for pandoc containers"
+	echo "  --notmp: Do not use a tempory directory for processing steps, instead create a directory called \"build\" in CWD"
+}
+
+
+options=$(getopt --longoptions=help,puppeteer,pdf,latex,docx,notmp,resouredir: --options="" -- "$@")
+if [ $? -ne 0 ]; then
+	echo "Incorrect options provided"
+	print_usage
+	exit 1
+fi
+
+eval set -- "${options}"
+while true; do
+	case "$1" in
+	--puppeteer)
+		do_puppeteer="yes"
+		shift
+		;;
+	--docx)
+		do_docx="yes"
+		shift
+		;;
+	--latex)
+		do_latex="yes"
+		shift
+		;;
+	--pdf)
+		do_pdf="yes"
+		shift
+		;;
+	--notmp)
+		is_tmp="no"
+		shift
+		;;
+	--resouredir)
+		resource_dir="${2}"
+		shift 2
+		;;
+	--help)
+		print_usage
+		shift
+		exit 0
+		;;
+	--)
+		shift
+		break
+		;;
+	esac
+	shift
+done
+
+shift "$(( OPTIND - 1 ))"
+
+# argcount check
+if [ $# -ne 1 ]; then
+	>&2 echo "Expected 1 markdown input file for processing, got: $*"
+	print_usage
+	exit 1
+fi
+
+# input file check
+input_file=$1
+if [ ! -e "${input_file}" ]; then
+   >&2 echo "${input_file} does not exist, exiting..."
+   exit 1
+fi
+
+# Set up the output directory, either tmp or build in pwd.
+if [ "${is_tmp}" == "yes" ]; then
+	build_dir="$(mktemp -d)"
+else
+	build_dir="$(pwd)/build"
+	mkdir -p "${build_dir}"
+fi
+
+# default to pdf enabled
+if [ "${do_pdf}${do_latex}${do_docx}" == "nonono" ]; then
+	do_pdf="yes"
+fi
+
+# Get the default browser
+if ! browser=$(command -v "chromium-browser"); then
+	if ! browser=$(command -v "google-chrome"); then
+		browser="none"
+	fi
+fi
+
+echo "Starting Build with"
+echo "puppeteer: ${do_puppeteer}"
+echo "docx: ${do_docx}"
+echo "pdf: ${do_pdf}"
+echo "latex: ${do_latex}"
+echo "use tmp: ${is_tmp}"
+echo "resource dir: ${resource_dir}"
+echo "build dir: ${build_dir}"
+echo "browser: ${browser}"
+
+if [ "${do_puppeteer}" == "yes" ]; then
+	if [ "${browser}" == "none" ]; then
+		>&2 echo "No Browser found, looked for chromium-browser and google-chrome"
+		exit 1
+	fi
+
+	# There are some configuration dependencies required for Mermaid.
+	# They have to be in the current directory.
+	cat <<- EOF > ./.puppeteer.json
+	{
+		"executablePath": "$browser",
+		"args": [
+			"--no-sandbox",
+			"--disable-setuid-sandbox"
+		]
+	}
+	EOF
+fi
+
+# Transform 1
+# GitHub Mermaid doesn't recognize the full ```{.mermaid ...} attributes-form
+# Pandoc doesn't recognized mixed ```mermaid {...} form
+# Hack: use sed to transform the former to the latter so everyone is happy
+sed 's/```mermaid *{/```{.mermaid /g' "${input_file}" > "${build_dir}/${input_file}.1"
+
+
+# Transform 2
+# \newpage is rendered as the string "\newpage" in GitHub markdown.
+# Transform horizontal rules into \newpages.
+# Exception: the YAML front matter of the document, so undo the instance on the first line.
+sed 's/^---$/\\newpage/g;1s/\\newpage/---/g' "${build_dir}/${input_file}.1" > "${build_dir}/${input_file}.2"
+
+# Transform 3
+# Transform sections before the table of contents into addsec, which does not number them.
+# While we're doing this, transform the case to all-caps.
+sed '0,/\\tableofcontents/s/^# \(.*\)/\\addsec\{\U\1\}/g' "${build_dir}/${input_file}.2" > "${build_dir}/${input_file}.3"
+
+# Grab the date from the front matter and generate the full date and year.
+DATE="$(grep date: "${input_file}" | head -n 1 | cut -d ' ' -f 2)"
+YEAR="$(date --date="${DATE}" +%Y)"
+DATE_ENGLISH="$(date --date="${DATE}" "+%B %-d, %Y")"
+
+# Run Pandoc
+export MERMAID_FILTER_THEME="forest"
+export MERMAID_FILTER_FORMAT="pdf"
+
+# Generate the pdf
+pdf_output="$(basename "${input_file}")".pdf
+if [ "${do_pdf}" = "yes" ]; then
+	pandoc \
+		--embed-resources \
+		--standalone \
+		--template=eisvogel.latex \
+		--filter=mermaid-filter \
+		--filter=pandoc-crossref \
+		--resource-path=.:/resources \
+		--data-dir=/resources \
+		--top-level-division=section \
+		--variable=block-headings \
+		--variable=numbersections \
+		--variable=table-use-row-colors \
+		--metadata=date-english:"${DATE_ENGLISH}" \
+		--metadata=year:"${YEAR}" \
+		--metadata=titlepage:true \
+		--metadata=titlepage-background:/resources/img/cover.png \
+		--metadata=logo:/resources/img/tcg.png \
+		--metadata=titlepage-rule-height:0 \
+		--metadata=colorlinks:true \
+		--metadata=contact:admin@trustedcomputinggroup.org \
+		--from=markdown+implicit_figures+table_captions \
+		--to=pdf \
+		"${build_dir}/${input_file}.3" \
+		--output="${pdf_output}"
+fi
+
+# Generate the LaTeX output
+latex_output="$(basename "${input_file}")".tex
+if [ "${do_latex}" = "yes" ]; then
+	pandoc \
+		--embed-resources \
+		--standalone \
+		--template=eisvogel.latex \
+		--filter=mermaid-filter \
+		--filter=pandoc-crossref \
+		--resource-path=.:/resources \
+		--data-dir=/resources \
+		--top-level-division=section \
+		--variable=block-headings \
+		--variable=numbersections \
+		--variable=table-use-row-colors \
+		--metadata=date-english:"${DATE_ENGLISH}" \
+		--metadata=year:"${YEAR}" \
+		--metadata=titlepage:true \
+		--metadata=titlepage-background:/resources/img/cover.png \
+		--metadata=logo:/resources/img/tcg.png \
+		--metadata=titlepage-rule-height:0 \
+		--metadata=colorlinks:true \
+		--metadata=contact:admin@trustedcomputinggroup.org \
+		--from=markdown+implicit_figures+table_captions \
+		--to=latex \
+		"${build_dir}/${input_file}.3" \
+		--output="${latex_output}"
+fi
+
+# Generate the docx output
+docx_output="$(basename "${input_file}")".docx
+if [ "${do_docx}" = "yes" ]; then
+	pandoc \
+		--embed-resources \
+		--standalone \
+		--filter=/resources/filters/info.py \
+		--filter=mermaid-filter \
+		--filter=pandoc-crossref \
+		--resource-path=.:/resources \
+		--data-dir=/resources \
+		--from=markdown+implicit_figures+table_captions \
+		--reference-doc=/resources/templates/tcg_template.docx \
+		--to=docx
+		"${build_dir}/${input_file}.3" \
+		--output="${docx_output}"
+fi
+

--- a/build.sh
+++ b/build.sh
@@ -259,6 +259,7 @@ export MERMAID_FILTER_FORMAT="pdf"
 if [ -n "${pdf_output}" ]; then
 	echo "Generating PDF Output"
 	pandoc \
+		--citeproc \
 		--embed-resources \
 		--standalone \
 		--template=eisvogel.latex \
@@ -278,7 +279,7 @@ if [ -n "${pdf_output}" ]; then
 		--metadata=titlepage-rule-height:0 \
 		--metadata=colorlinks:true \
 		--metadata=contact:admin@trustedcomputinggroup.org \
-		--from=markdown+implicit_figures+table_captions \
+		--from=markdown+implicit_figures+table_captions+citations \
 		${extra_pandoc_options} \
 		--to=pdf \
 		"${build_dir}/${input_file}.3" \
@@ -290,6 +291,7 @@ fi
 if [ -n "${latex_output}" ]; then
 	echo "Generating LaTeX Output"
 	pandoc \
+		--citeproc \
 		--embed-resources \
 		--standalone \
 		--template=eisvogel.latex \
@@ -309,7 +311,7 @@ if [ -n "${latex_output}" ]; then
 		--metadata=titlepage-rule-height:0 \
 		--metadata=colorlinks:true \
 		--metadata=contact:admin@trustedcomputinggroup.org \
-		--from=markdown+implicit_figures+table_captions \
+		--from=markdown+implicit_figures+table_captions+citations \
 		${extra_pandoc_options} \
 		--to=latex \
 		"${build_dir}/${input_file}.3" \
@@ -321,6 +323,7 @@ fi
 if [ -n "${docx_output}" ]; then
 	echo "Generating DOCX Output"
 	pandoc \
+		--citeproc \
 		--embed-resources \
 		--standalone \
 		--filter=/resources/filters/info.py \
@@ -328,7 +331,7 @@ if [ -n "${docx_output}" ]; then
 		--filter=pandoc-crossref \
 		--resource-path=.:/resources \
 		--data-dir=/resources \
-		--from=markdown+implicit_figures+table_captions \
+		--from=markdown+implicit_figures+table_captions+citations \
 		--reference-doc=/resources/templates/tcg_template.docx \
 		${extra_pandoc_options} \
 		--to=docx \

--- a/build.sh
+++ b/build.sh
@@ -3,6 +3,7 @@
 is_tmp="yes"	  # default to no tmp directory
 resource_dir="/"  #default to root of pandoc container buildout
 do_puppeteer="no"
+do_gitversion="no"
 pdf_output=""
 docx_output=""
 latex_output=""
@@ -34,10 +35,11 @@ print_usage() {
 	echo "  --puppeteer: enable outputing of .puppeteer.json in current directory. This is needed for running in sandboxes eg docker containers."
 	echo "  --resouredir=dir: Set the resource directory, defaults to root for pandoc containers"
 	echo "  --notmp: Do not use a tempory directory for processing steps, instead create a directory called \"build\" in CWD"
+	echo "  --gitversion: Use git describe to generate document version and revision metadata."
 }
 
 
-if ! options=$(getopt --longoptions=help,puppeteer,pdf:,latex:,docx:,notmp,resouredir: --options="" -- "$@"); then
+if ! options=$(getopt --longoptions=help,puppeteer,notmp,gitversion,pdf:,latex:,docx:,resouredir: --options="" -- "$@"); then
 	echo "Incorrect options provided"
 	print_usage
 	exit 1
@@ -46,9 +48,17 @@ fi
 eval set -- "${options}"
 while true; do
 	case "$1" in
+	--gitversion)
+		do_gitversion="yes"
+		shift
+		;;
 	--puppeteer)
 		do_puppeteer="yes"
-		shift 2
+		shift
+		;;
+	--notmp)
+		is_tmp="no"
+		shift
 		;;
 	--docx)
 		docx_output="${2}"
@@ -61,10 +71,6 @@ while true; do
 	--pdf)
 		pdf_output="${2}"
 		shift 2
-		;;
-	--notmp)
-		is_tmp="no"
-		shift
 		;;
 	--resouredir)
 		resource_dir="${2}"
@@ -119,6 +125,53 @@ if ! browser=$(command -v "chromium-browser"); then
 	fi
 fi
 
+# figure out git version and revision if needed.
+extra_pandoc_options=""
+if test "${do_gitversion}" == "yes"; then
+
+	# TODO: Should we fail if dirty?
+	raw_version="$(git describe --always --tags)"
+	IFS='-' read -r -a dash_hunks <<< "${raw_version}"
+
+    # Could be one of:
+    # gabcd - commit no tag (len 1)
+   	# 4 --> tag major only (len 1)
+	# 4.0 --> tag major minor (len 1)
+	# 4-54-gabcd --> tag major with commits (len 3)
+	# 4.0-54-gabcd --> tag major-minor with commits (len 3)
+	len=${#dash_hunks[@]}
+	if ! test "${len}" -eq 1 -o "${len}" -eq 3; then
+	    >&2 echo "Malformed git version got: ${raw_version}"
+	    exit 1
+    fi
+
+	revision="0"
+	major_minor="${dash_hunks[0]}"
+	if test "${len}" -eq 3; then
+		revision="${dash_hunks[1]}"
+	fi
+
+	# Does this even have a major minor, or is it just a commit (8d7046adcf1b) len of 12 no dot char?
+	# Note that in docker image this sha is shorter at 7 chars for some reason.
+	if grep -qv '\.' <<< "${major_minor}"; then
+		if test ${#major_minor} -ge 7; then
+
+			# its a commit
+			major_minor="0.0"
+			revision="$(git rev-list --count HEAD)"
+		else
+			# its a major with no minor, append .0
+			major_minor="${major_minor}.0"
+		fi
+	fi
+
+	# scrub any leading non-numerical arguments from major_minor, ie v4.0, scrub any other nonsense as well
+	major_minor="$(tr -d "[:alpha:]" <<< "${major_minor}")"
+
+	extra_pandoc_options="--metadata=version:${major_minor} --metadata=revision:${revision}"
+
+fi # Done with git version handling
+
 echo "Starting Build with"
 echo "file: ${input_file}"
 echo "puppeteer: ${do_puppeteer}"
@@ -129,6 +182,12 @@ echo "use tmp: ${is_tmp}"
 echo "resource dir: ${resource_dir}"
 echo "build dir: ${build_dir}"
 echo "browser: ${browser}"
+echo "use git version: ${do_gitversion}"
+if test "${do_gitversion}" == "yes"; then
+	echo "Git Generated Document Version Information"
+	echo "    version: ${major_minor}"
+	echo "    revision: ${revision}"
+fi
 
 if [ "${do_puppeteer}" == "yes" ]; then
 	if [ "${browser}" == "none" ]; then
@@ -200,6 +259,7 @@ if [ -n "${pdf_output}" ]; then
 		--metadata=colorlinks:true \
 		--metadata=contact:admin@trustedcomputinggroup.org \
 		--from=markdown+implicit_figures+table_captions \
+		${extra_pandoc_options} \
 		--to=pdf \
 		"${build_dir}/${input_file}.3" \
 		--output="${pdf_output}"
@@ -230,6 +290,7 @@ if [ -n "${latex_output}" ]; then
 		--metadata=colorlinks:true \
 		--metadata=contact:admin@trustedcomputinggroup.org \
 		--from=markdown+implicit_figures+table_captions \
+		${extra_pandoc_options} \
 		--to=latex \
 		"${build_dir}/${input_file}.3" \
 		--output="${latex_output}"
@@ -249,6 +310,7 @@ if [ -n "${docx_output}" ]; then
 		--data-dir=/resources \
 		--from=markdown+implicit_figures+table_captions \
 		--reference-doc=/resources/templates/tcg_template.docx \
+		${extra_pandoc_options} \
 		--to=docx \
 		"${build_dir}/${input_file}.3" \
 		--output="${docx_output}"

--- a/docker_run
+++ b/docker_run
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+docker_image=${DOCKER_IMAGE:-"ghcr.io/trustedcomputinggroup/pandoc:latest"}
+
+print_usage() {
+	echo "Usage:"
+	echo "$(basename "${0}") [options] [build.sh arguments]"
+	echo
+	echo "Arguments:"
+	echo "  Arguments to this script are passed as parameters to build.sh inside of the docker conatiner"
+	echo
+	echo "Environment:"
+	echo
+	echo "DOCKER_IMAGE: set this env variable to the docker image to run, defaults to ${docker_image}"
+	echo
+	echo "Options:"
+	echo
+	echo "Miscellaneous"
+	echo "  --help: output this message"
+}
+
+# hand process options as we want all options to go to docker run command except ones we know
+if test "${1}" == "--help"; then
+	print_usage
+	exit 0
+fi
+
+echo "Launching Container: ${docker_image}"
+docker run -v "$(pwd):/workspace" --user="$(id -u):$(id -g)" -w/workspace "${docker_image}" "$@"

--- a/sample3.md
+++ b/sample3.md
@@ -1,0 +1,153 @@
+---
+title: "Important TCG Document"
+date-english: August 11, 2022
+date: 8/11/2022
+year: 2022
+type: SPECIFICATION
+status: PUBLISHED
+template: bluetop
+...
+
+\newpage
+
+# Disclaimers, Notices, and License Terms
+
+THIS SPECIFICATION IS PROVIDED “AS IS” WITH NO WARRANTIES WHATSOEVER, INCLUDING
+ANY WARRANTY OF MERCHANTABILITY, NONINFRINGEMENT, FITNESS FOR ANY PARTICULAR
+PURPOSE, OR ANY WARRANTY OTHERWISE ARISING OUT OF ANY PROPOSAL, SPECIFICATION OR
+SAMPLE.
+
+Without limitation, TCG disclaims all liability, including liability for
+infringement of any proprietary rights, relating to use of information in this
+specification and to the implementation of this specification, and TCG disclaims
+all liability for cost of procurement of substitute goods or services, lost
+profits, loss of use, loss of data or any incidental, consequential, direct,
+indirect, or special damages, whether under contract, tort, warranty or
+otherwise, arising in any way out of use or reliance upon this specification or
+any information herein. This document is copyrighted by Trusted Computing Group
+(TCG), and no license, express or implied, is granted herein other than as
+follows: You may not copy or reproduce the document or distribute it to others
+without written permission from TCG, except that you may freely do so for the
+purposes of (a) examining or implementing TCG specifications or (b) developing,
+testing, or promoting information technology standards and best practices, so long
+as you distribute the document with these disclaimers, notices, and license terms.
+Contact the Trusted Computing Group at www.trustedcomputinggroup.org for
+information on specification licensing through membership agreements. Any marks
+and brands contained herein are the property of their respective owners.
+
+---
+
+# Change History
+
+| **Revision** | **Date**   | **Description** |
+| ------------ | ---------- | --------------- |
+| 0.2/17       | 2022/08/10 | Initial draft   |
+| 0.2/18       | 2022/08/10 | Add page breaks |
+
+---
+
+\tableofcontents
+\listoftables
+\listoffigures
+
+---
+
+# Introduction
+
+Published specification with a list of figures.
+
+## Details
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis
+nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu
+fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
+culpa qui officia deserunt mollit anim id est laborum.
+
+## Figures
+
+### Computer
+
+To include an image in the list of figures, use the "#fig" attribute.
+
+![a computer](computer.jpg){#fig:computer}
+
+### Sequence
+
+To include a Mermaid diagram in the list of figures, use the "caption" option.
+
+See the [mermaid-filter documentation](https://github.com/raghur/mermaid-filter#options)
+for a list of all the options.
+
+```{.mermaid caption="startup"}
+sequenceDiagram
+Host->>TPM: TPM2_Startup
+loop Measurements
+    Host->>TPM: TPM2_PCR_Extend
+end
+Host->>TPM: TPM2_Quote
+TPM->>Host: <quoted PCRs>
+```
+
+### Flowchart
+
+```{.mermaid caption="abcd"}
+graph TD;
+    A-->B;
+    A-->C;
+    B-->D;
+    C-->D;
+```
+
+### Mandatory Algorithms
+
+Table: List of Mandatory Algorithms
+
+| **Algorithm ID** | **M/R/O/D** | **Comments**                                  |
+| ---------------- | ----------- | --------------------------------------------- |
+| TPM_ALG_ECC      | M           | Support for 256 and 384-bit keys is required. |
+| TPM_ALG_ECDSA    | M           |
+| TPM_ALG_ECDH     | M           |
+| TPM_ALG_ECDAA    | O           |
+| TPM_ALG_RSA      | O           |
+| TPM_ALG_RSAES    | O           |
+| TPM_ALG_RSAPSS   | O           |
+| TPM_ALG_RSAOAEP  | O           |
+| TPM_ALG_AES      | M           |
+| TPM_ALG_SHA256   | M           |
+| TPM_ALG_SHA384   | M           |
+| TPM_ALG_SHA512   | O           |
+| TPM_ALG_HMAC     | M           |
+| TPM_ALG_SHA3_256 | O           |
+| TPM_ALG_SHA3_384 | O           |
+| TPM_ALG_SHA3_512 | O           |
+| TPM_ALG_NULL     | M           |
+
+### Mandatory Curves
+
+Table: List of Mandatory Curves
+
+| **Curve Identifier** | **M/R/O/D** | **Comments** |
+| -------------------- | ----------- | ------------ |
+| TPM_ECC_NIST_P256    | M           |
+| TPM_ECC_NIST_P384    | M           |
+
+## Code
+
+```c++
+#include <string>
+
+int main() {
+    std::string result = "Trusted Computing Group";
+    return 1;
+}
+```
+
+## Another Table
+
+Table: Fantastic Table
+
+| **Column 1** | **Column 2** | **Column 3** |
+| ------------ | ------------ | ------------ |
+| AAAAAAAA     | BBBBBBBB     | CCCCCCCC     |


### PR DESCRIPTION
Add build scripts to make building documentation from source markdown simpler for end users.

- This adds a script build.sh and defines the default entry point as build.sh.
- This also adds a docker_run command to make running the container easier for end users.
- Adds git versioning support from git-describe. Fixes #31 

TODO:
  - Add a test for the docker container
  - Figure out workflows.

Current Issues I see:

**The PR builds and publishes docker container**
    a. Requires perms on incoming PRs which should be treated as untrusted even through it's inter-org. Don't trust Bill.
    b. PRs race on publishing the image

_Proposal_: for PRs and pushes, do a docker build and docker run manually. The images for github actions contain all the 
docker things, no need to really use the composite actions or reusable workflows for that. Only on push should publish the
container to the registry. Do we really need to publish and check-in the generated files?

**Composite Workflows**
IIUC it's a composite workflow others are using to generate the markdown rendering. However, it requires users to setup the docker container. I think if we move to a reusable workflow, we can move all of the setup into a reusable workflow so callers of the workflow don't have to do anything but use it. Additionally we can just use docker_run, no real need for the docker actions as docker run will pull the image.

**markdown project**
Do we need this? The pandoc project builds out the samples anyways, couldn't we just coalesce them or is the markdown project exist soley to test the action.yml composite workflow? It seems confusing to have so much stuff spread out, i'm not seeing the value in the decomposition.

    