### PR TITLE
Remove workaround related to subsection page wrapping

### DIFF
--- a/template/eisvogel.latex
+++ b/template/eisvogel.latex
@@ -692,14 +692,6 @@ $endif$
   beforeskip=.5\baselineskip,
   afterskip=0em]{subparagraph}
 
-% % Subsections don't wrap to a new page by default.
-% % Workaround from https://tex.stackexchange.com/questions/162236/subsection-on-new-page-if-it-doesnt-fit
-\preto{\section}{\clearpageafterfirst}
-\preto{\subsection}{\filbreak}
-\newcommand{\clearpageafterfirst}{%
-  \gdef\clearpageafterfirst{\clearpage}%
-}
-
 % Allow TCG documents to use '\beginappendices' to easily mark the transition to appendices.
 \usepackage{appendix}
 \newcommand{\beginappendices}{

--- a/template/eisvogel.latex
+++ b/template/eisvogel.latex
@@ -400,10 +400,10 @@ $endif$
 \newunicodechar{→}{\textfallback{→}}
 
 %
-% heading color
+% Set the heading color and ensure that every section begins on its own page.
 %
 \definecolor{heading-color}{RGB}{35,61,130}
-\addtokomafont{section}{\color{heading-color}}
+\addtokomafont{section}{\clearpage \color{heading-color}}
 
 %
 % variables for title, author and date


### PR DESCRIPTION
This workaround that involved invoking \clearpageafterfirst seems to wreak havoc on long tables when they are positioned in just the wrong way.

Fixes #64 