### PR TITLE
use XITS for math typesetting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,8 @@ RUN tlmgr update --self && \
     changepage \
     draftwatermark \
     appendix \
-    multirow
+    multirow \
+    xits
 
 RUN apk upgrade && apk add --no-cache \
     bash \

--- a/build.sh
+++ b/build.sh
@@ -315,9 +315,11 @@ if [ -n "${pdf_output}" ]; then
 		${extra_pandoc_options} \
 		--to=pdf \
 		--output="${pdf_output}"
-	echo "PDF Output Generated to file: ${pdf_output}"
 	if [ $? -ne 0 ]; then
 		RESULT=$?
+		echo "PDF output failed"
+	else
+		echo "PDF output generated to file: ${pdf_output}"
 	fi
 fi
 
@@ -358,9 +360,11 @@ if [ -n "${latex_output}" ]; then
 		${extra_pandoc_options} \
 		--to=latex \
 		--output="${latex_output}"
-	echo "LaTeX Output Generated to file: ${latex_output}"
 	if [ $? -ne 0 ]; then
 		RESULT=$?
+		echo "LaTeX output failed"
+	else
+		echo "LaTeX output generated to file: ${latex_output}"
 	fi
 fi
 
@@ -391,9 +395,11 @@ if [ -n "${docx_output}" ]; then
 		${extra_pandoc_options} \
 		--to=docx \
 		--output="${docx_output}"
-	echo "DOCX Output Generated to file: ${docx_output}"
 	if [ $? -ne 0 ]; then
 		RESULT=$?
+		echo "DOCX output failed"
+	else
+		echo "DOCX output generated to file: ${docx_output}"
 	fi
 fi
 
@@ -439,9 +445,11 @@ if [ -n "${html_output}" ]; then
 		${extra_pandoc_options} \
 		--to=html \
 		--output="${html_output}"
-	echo "HTML Output Generated to file: ${html_output}"
 	if [ $? -ne 0 ]; then
 		RESULT=$?
+		echo "HTML output failed"
+	else
+		echo "HTML output generated to file: ${html_output}"
 	fi
 fi
 

--- a/guide.md
+++ b/guide.md
@@ -729,13 +729,13 @@ $$ \nexists {n \ge 3; a, b, c \in \mathbb{Z}} \mid a^n + b^n = c^n $$ {#eq:ferma
 Sometimes, you just need a little inline math in the middle of a sentence, like with `$a^2 + b^2 = c^2$` to get $a^2 + b^2 = c^2$.
 
 ```md
-$$ \mathit{HMAC}(K, \mathrm{"text"}) \coloneq H((\bar{K} \oplus \mathrm{OPAD}) \Vert H((\bar{K} \oplus \mathrm{IPAD}) \Vert \mathrm{"text"})) $$ {#eq:hmac-iso}
+$$ \mathbf{HMAC}(K, \mathrm{"text"}) \coloneq H((\bar{K} \oplus \mathrm{OPAD}) \Vert H((\bar{K} \oplus \mathrm{IPAD}) \Vert \mathrm{"text"})) $$ {#eq:hmac-iso}
 ```
 
-$$ \mathit{HMAC}(K, \mathrm{"text"}) \coloneq H((\bar{K} \oplus \mathrm{OPAD}) \Vert H((\bar{K} \oplus \mathrm{IPAD}) \Vert \mathrm{"text"})) $$ {#eq:hmac-iso}
+$$ \mathbf{HMAC}(K, \mathrm{"text"}) \coloneq H((\bar{K} \oplus \mathrm{OPAD}) \Vert H((\bar{K} \oplus \mathrm{IPAD}) \Vert \mathrm{"text"})) $$ {#eq:hmac-iso}
 
 To typeset complex equations with multi-character identifiers (such as the function "HMAC" or the word "OPAD") in @eq:hmac-iso above,
-we recommend using the functions `\mathit` (for functions) and `\mathrm` (for identifiers). This avoids strange kerning issues like in @q:hmac-iso-bad-kerning:
+we recommend using the functions `\mathbf` (for functions) and `\mathrm` (for identifiers). This avoids strange kerning issues like in @q:hmac-iso-bad-kerning:
 
 ```md
 $$ HMAC(K, "text") \coloneq H((\bar{K} \oplus OPAD) \Vert H((\bar{K} \oplus IPAD) \Vert "text")) $$ {#eq:hmac-iso-bad-kerning}

--- a/guide.md
+++ b/guide.md
@@ -735,7 +735,7 @@ $$ \symbf{HMAC}(K, \symup{"text"}) \coloneq H((\bar{K} \oplus \symup{OPAD}) \Ver
 $$ \symbf{HMAC}(K, \symup{"text"}) \coloneq H((\bar{K} \oplus \symup{OPAD}) \Vert H((\bar{K} \oplus \symup{IPAD}) \Vert \symup{"text"})) $$ {#eq:hmac-iso}
 
 To typeset complex equations with multi-character identifiers (such as the function "HMAC" or the word "OPAD") in @eq:hmac-iso above,
-we recommend using the functions `\symbf` (for functions) and `\symup` (for identifiers). This avoids strange kerning issues like in @q:hmac-iso-bad-kerning:
+we recommend using the functions `\symbf` (for functions) and `\symup` (for identifiers). This avoids strange kerning issues like in @eq:hmac-iso-bad-kerning:
 
 ```md
 $$ HMAC(K, "text") \coloneq H((\bar{K} \oplus OPAD) \Vert H((\bar{K} \oplus IPAD) \Vert "text")) $$ {#eq:hmac-iso-bad-kerning}

--- a/guide.md
+++ b/guide.md
@@ -729,10 +729,10 @@ $$ \nexists {n \ge 3; a, b, c \in \mathbb{Z}} \mid a^n + b^n = c^n $$ {#eq:ferma
 Sometimes, you just need a little inline math in the middle of a sentence, like with `$a^2 + b^2 = c^2$` to get $a^2 + b^2 = c^2$.
 
 ```md
-$$ \mathit{HMAC}(K, \mathrm{text}) \coloneq H((\bar{K} \oplus \mathrm{OPAD}) \Vert H((\bar{K} \oplus \mathrm{IPAD}) \Vert \mathrm{text})) $$ {#eq:hmac-iso}
+$$ \mathit{HMAC}(K, \mathrm{"text"}) \coloneq H((\bar{K} \oplus \mathrm{OPAD}) \Vert H((\bar{K} \oplus \mathrm{IPAD}) \Vert \mathrm{"text"})) $$ {#eq:hmac-iso}
 ```
 
-$$ \mathit{HMAC}(K, \mathrm{text}) \coloneq H((\bar{K} \oplus \mathrm{OPAD}) \Vert H((\bar{K} \oplus \mathrm{IPAD}) \Vert \mathrm{text})) $$ {#eq:hmac-iso}
+$$ \mathit{HMAC}(K, \mathrm{"text"}) \coloneq H((\bar{K} \oplus \mathrm{OPAD}) \Vert H((\bar{K} \oplus \mathrm{IPAD}) \Vert \mathrm{"text"})) $$ {#eq:hmac-iso}
 
 To typeset complex equations with multi-character identifiers (such as the function "HMAC" or the word "OPAD") in @eq:hmac-iso above,
 we recommend using the functions `\mathit` (for functions) and `\mathrm` (for identifiers). This avoids strange kerning issues like in @q:hmac-iso-bad-kerning:

--- a/guide.md
+++ b/guide.md
@@ -728,6 +728,22 @@ $$ \nexists {n \ge 3; a, b, c \in \mathbb{Z}} \mid a^n + b^n = c^n $$ {#eq:ferma
 
 Sometimes, you just need a little inline math in the middle of a sentence, like with `$a^2 + b^2 = c^2$` to get $a^2 + b^2 = c^2$.
 
+```md
+$$ \mathit{HMAC}(K, \mathrm{text}) \coloneq H((\bar{K} \oplus \mathrm{OPAD}) \Vert H((\bar{K} \oplus \mathrm{IPAD}) \Vert \mathrm{text})) $$ {#eq:hmac-iso}
+```
+
+$$ \mathit{HMAC}(K, \mathrm{text}) \coloneq H((\bar{K} \oplus \mathrm{OPAD}) \Vert H((\bar{K} \oplus \mathrm{IPAD}) \Vert \mathrm{text})) $$ {#eq:hmac-iso}
+
+To typeset complex equations with multi-character identifiers (such as the function "HMAC" or the word "OPAD") in @eq:hmac-iso above,
+we recommend using the functions `\mathit` (for functions) and `\mathrm` (for identifiers). This avoids strange kerning issues like in @q:hmac-iso-bad-kerning:
+
+```md
+$$ \mathit{HMAC}(K, text) \coloneq H((\bar{K} \oplus OPAD) \Vert H((\bar{K} \oplus IPAD) \Vert text)) $$ {#eq:hmac-iso-bad-kerning}
+```
+
+$$ \mathit{HMAC}(K, text) \coloneq H((\bar{K} \oplus OPAD) \Vert H((\bar{K} \oplus IPAD) \Vert text)) $$ {#eq:hmac-iso-bad-kerning}
+
+
 \beginappendices
 
 # Reporting Issues with the Tools

--- a/guide.md
+++ b/guide.md
@@ -738,10 +738,10 @@ To typeset complex equations with multi-character identifiers (such as the funct
 we recommend using the functions `\mathit` (for functions) and `\mathrm` (for identifiers). This avoids strange kerning issues like in @q:hmac-iso-bad-kerning:
 
 ```md
-$$ \mathit{HMAC}(K, text) \coloneq H((\bar{K} \oplus OPAD) \Vert H((\bar{K} \oplus IPAD) \Vert text)) $$ {#eq:hmac-iso-bad-kerning}
+$$ \mathit{HMAC}(K, "text") \coloneq H((\bar{K} \oplus OPAD) \Vert H((\bar{K} \oplus IPAD) \Vert "text")) $$ {#eq:hmac-iso-bad-kerning}
 ```
 
-$$ \mathit{HMAC}(K, text) \coloneq H((\bar{K} \oplus OPAD) \Vert H((\bar{K} \oplus IPAD) \Vert text)) $$ {#eq:hmac-iso-bad-kerning}
+$$ \mathit{HMAC}(K, "text") \coloneq H((\bar{K} \oplus OPAD) \Vert H((\bar{K} \oplus IPAD) \Vert "text")) $$ {#eq:hmac-iso-bad-kerning}
 
 
 \beginappendices

--- a/guide.md
+++ b/guide.md
@@ -738,10 +738,10 @@ To typeset complex equations with multi-character identifiers (such as the funct
 we recommend using the functions `\mathit` (for functions) and `\mathrm` (for identifiers). This avoids strange kerning issues like in @q:hmac-iso-bad-kerning:
 
 ```md
-$$ \mathit{HMAC}(K, "text") \coloneq H((\bar{K} \oplus OPAD) \Vert H((\bar{K} \oplus IPAD) \Vert "text")) $$ {#eq:hmac-iso-bad-kerning}
+$$ HMAC(K, "text") \coloneq H((\bar{K} \oplus OPAD) \Vert H((\bar{K} \oplus IPAD) \Vert "text")) $$ {#eq:hmac-iso-bad-kerning}
 ```
 
-$$ \mathit{HMAC}(K, "text") \coloneq H((\bar{K} \oplus OPAD) \Vert H((\bar{K} \oplus IPAD) \Vert "text")) $$ {#eq:hmac-iso-bad-kerning}
+$$ HMAC(K, "text") \coloneq H((\bar{K} \oplus OPAD) \Vert H((\bar{K} \oplus IPAD) \Vert "text")) $$ {#eq:hmac-iso-bad-kerning}
 
 
 \beginappendices

--- a/guide.md
+++ b/guide.md
@@ -716,6 +716,8 @@ To get an HTML table to word-wrap its contents, use `<colgroup>` to style the wi
 
 # Math {#sec:math}
 
+## Equations
+
 Markdown supports inline math notation. For example, @eq:fermat can be typeset as:
 
 ```md
@@ -726,23 +728,27 @@ Note the `{#eq:fermat}` at the end of the equation. This allows referencing @eq:
 
 $$ \nexists {n \ge 3; a, b, c \in \mathbb{Z}} \mid a^n + b^n = c^n $$ {#eq:fermat}
 
+## Inline math
+
 Sometimes, you just need a little inline math in the middle of a sentence, like with `$a^2 + b^2 = c^2$` to get $a^2 + b^2 = c^2$.
 
+## Words in equations
+
+To typeset complex equations with multi-character identifiers (such as the function "HMAC" or the word "OPAD") in @eq:hmac-iso,
+we recommend using the functions `\symbf` (for functions) and `\symup` (for identifiers).
+This avoids strange kerning issues where a string is treated as a product of single-character symbols, like in @eq:hmac-iso-bad-kerning:
+
 ```md
 $$ \symbf{HMAC}(K, \symup{"text"}) \coloneq H((\bar{K} \oplus \symup{OPAD}) \Vert H((\bar{K} \oplus \symup{IPAD}) \Vert \symup{"text"})) $$ {#eq:hmac-iso}
 ```
 
 $$ \symbf{HMAC}(K, \symup{"text"}) \coloneq H((\bar{K} \oplus \symup{OPAD}) \Vert H((\bar{K} \oplus \symup{IPAD}) \Vert \symup{"text"})) $$ {#eq:hmac-iso}
 
-To typeset complex equations with multi-character identifiers (such as the function "HMAC" or the word "OPAD") in @eq:hmac-iso above,
-we recommend using the functions `\symbf` (for functions) and `\symup` (for identifiers). This avoids strange kerning issues like in @eq:hmac-iso-bad-kerning:
-
 ```md
 $$ HMAC(K, "text") \coloneq H((\bar{K} \oplus OPAD) \Vert H((\bar{K} \oplus IPAD) \Vert "text")) $$ {#eq:hmac-iso-bad-kerning}
 ```
 
 $$ HMAC(K, "text") \coloneq H((\bar{K} \oplus OPAD) \Vert H((\bar{K} \oplus IPAD) \Vert "text")) $$ {#eq:hmac-iso-bad-kerning}
-
 
 \beginappendices
 

--- a/guide.md
+++ b/guide.md
@@ -729,13 +729,13 @@ $$ \nexists {n \ge 3; a, b, c \in \mathbb{Z}} \mid a^n + b^n = c^n $$ {#eq:ferma
 Sometimes, you just need a little inline math in the middle of a sentence, like with `$a^2 + b^2 = c^2$` to get $a^2 + b^2 = c^2$.
 
 ```md
-$$ \mathbf{HMAC}(K, \mathrm{"text"}) \coloneq H((\bar{K} \oplus \mathrm{OPAD}) \Vert H((\bar{K} \oplus \mathrm{IPAD}) \Vert \mathrm{"text"})) $$ {#eq:hmac-iso}
+$$ \symbf{HMAC}(K, \symup{"text"}) \coloneq H((\bar{K} \oplus \symup{OPAD}) \Vert H((\bar{K} \oplus \symup{IPAD}) \Vert \symup{"text"})) $$ {#eq:hmac-iso}
 ```
 
-$$ \mathbf{HMAC}(K, \mathrm{"text"}) \coloneq H((\bar{K} \oplus \mathrm{OPAD}) \Vert H((\bar{K} \oplus \mathrm{IPAD}) \Vert \mathrm{"text"})) $$ {#eq:hmac-iso}
+$$ \symbf{HMAC}(K, \symup{"text"}) \coloneq H((\bar{K} \oplus \symup{OPAD}) \Vert H((\bar{K} \oplus \symup{IPAD}) \Vert \symup{"text"})) $$ {#eq:hmac-iso}
 
 To typeset complex equations with multi-character identifiers (such as the function "HMAC" or the word "OPAD") in @eq:hmac-iso above,
-we recommend using the functions `\mathbf` (for functions) and `\mathrm` (for identifiers). This avoids strange kerning issues like in @q:hmac-iso-bad-kerning:
+we recommend using the functions `\symbf` (for functions) and `\symup` (for identifiers). This avoids strange kerning issues like in @q:hmac-iso-bad-kerning:
 
 ```md
 $$ HMAC(K, "text") \coloneq H((\bar{K} \oplus OPAD) \Vert H((\bar{K} \oplus IPAD) \Vert "text")) $$ {#eq:hmac-iso-bad-kerning}

--- a/template/eisvogel.latex
+++ b/template/eisvogel.latex
@@ -402,9 +402,9 @@ $endif$
 \setmathfont{XITS Math}
 
 % Customize the spacing for math to relax it a bit.
-\setlength{\thinmuskip}{6mu}
-\setlength{\medmuskip}{8mu plus 4mu minus 6mu}
-\setlength{\thickmuskip}{10mu plus 10mu}
+\thinmuskip=6mu
+\medmuskip=8mu plus 4mu minus 2mu
+\thickmuskip=10mu plus 10mu
 
 \defaultfontfeatures{Scale=MatchLowercase}
 \defaultfontfeatures[\rmfamily]{Ligatures=TeX,Scale=1}

--- a/template/eisvogel.latex
+++ b/template/eisvogel.latex
@@ -70,8 +70,6 @@ $endif$
 \setstretch{1.0}
 \usepackage[absolute,overlay]{textpos}
 \usepackage{ifxetex,ifluatex}
-\usepackage[mathit=sym]{unicode-math}
-\setmathfont{Latin Modern Math}
 
 % Customize the glue for math to relax the spacing a bit.
 % https://www.reddit.com/r/LaTeX/comments/10qdg9s/is_it_possible_to_slightly_increase_all/
@@ -388,11 +386,14 @@ $endif$
 \usepackage{fontspec}
 \setmainfont{Arial}
 \setsansfont{Arial}
-\setmathsf{Arial}
+% \setmathsf{Arial}
 \setmonofont{Noto Sans Mono}
-\setmathtt{Noto Sans Mono}
+% \setmathtt{Noto Sans Mono}
 % TODO: Understand the redundancy with the unicode-math font setting above.
-\setmathrm{Latin Modern Math}
+% \setmathrm{Latin Modern Math}
+
+\usepackage[mathit=sym]{unicode-math}
+\setmathfont{Latin Modern Math}
 
 \usepackage{newunicodechar}
 % Use Arial Unicode to display various unicode symbols that might be present

--- a/template/eisvogel.latex
+++ b/template/eisvogel.latex
@@ -73,6 +73,12 @@ $endif$
 \usepackage{unicode-math}
 \setmathfont{Latin Modern Math}
 
+% Customize the glue for math to relax the spacing a bit.
+% https://www.reddit.com/r/LaTeX/comments/10qdg9s/is_it_possible_to_slightly_increase_all/
+\thinmuskip=6mu
+\medmuskip=8mu plus 4mu minus 6mu
+\thickmuskip=10mu plus 10mu
+
 \defaultfontfeatures{Scale=MatchLowercase}
 \defaultfontfeatures[\rmfamily]{Ligatures=TeX,Scale=1}
 
@@ -379,14 +385,11 @@ $endif$
   skipabove=\parskip,
   nobreak=true]{customcodeblock}
 
-\usepackage{fontspec}
+% Pass 'no-math' here to let unicode-math above handle the math fonts.
+\usepackage{fontspec}[no-math]
 \setmainfont{Arial}
 \setsansfont{Arial}
 \setmonofont{Noto Sans Mono}
-
-\setmathrm{Latin Modern Math}
-\setmathsf{Arial}
-\setmathtt{Noto Sans Mono}
 
 \usepackage{newunicodechar}
 % Use Arial Unicode to display various unicode symbols that might be present

--- a/template/eisvogel.latex
+++ b/template/eisvogel.latex
@@ -71,15 +71,6 @@ $endif$
 \usepackage[absolute,overlay]{textpos}
 \usepackage{ifxetex,ifluatex}
 
-% Customize the glue for math to relax the spacing a bit.
-% https://www.reddit.com/r/LaTeX/comments/10qdg9s/is_it_possible_to_slightly_increase_all/
-\thinmuskip=6mu
-\medmuskip=8mu plus 4mu minus 6mu
-\thickmuskip=10mu plus 10mu
-
-\defaultfontfeatures{Scale=MatchLowercase}
-\defaultfontfeatures[\rmfamily]{Ligatures=TeX,Scale=1}
-
 $if(luatexjapresetoptions)$
   \ifluatex{}
     \usepackage[$for(luatexjapresetoptions)$$luatexjapresetoptions$$sep$,$endfor$]{luatexja-preset}
@@ -392,9 +383,6 @@ $endif$
 % TODO: Understand the redundancy with the unicode-math font setting above.
 % \setmathrm{Latin Modern Math}
 
-\usepackage[mathit=sym]{unicode-math}
-\setmathfont{XITS Math}
-
 \usepackage{newunicodechar}
 % Use Arial Unicode to display various unicode symbols that might be present
 \newfontfamily{\fallbackfont}{Arial Unicode MS}[Scale=MatchLowercase]
@@ -413,6 +401,18 @@ $endif$
 \newunicodechar{©}{\textfallback{©}}
 \newunicodechar{™}{\textfallback{™}}
 \newunicodechar{→}{\textfallback{→}}
+
+\usepackage[mathit=sym]{unicode-math}
+\setmathfont{XITS Math}
+
+% Customize the glue for math to relax the spacing a bit.
+% https://www.reddit.com/r/LaTeX/comments/10qdg9s/is_it_possible_to_slightly_increase_all/
+\thinmuskip=6mu
+\medmuskip=8mu plus 4mu minus 6mu
+\thickmuskip=10mu plus 10mu
+
+\defaultfontfeatures{Scale=MatchLowercase}
+\defaultfontfeatures[\rmfamily]{Ligatures=TeX,Scale=1}
 
 %
 % Set the heading color and ensure that every section begins on its own page.

--- a/template/eisvogel.latex
+++ b/template/eisvogel.latex
@@ -70,7 +70,7 @@ $endif$
 \setstretch{1.0}
 \usepackage[absolute,overlay]{textpos}
 \usepackage{ifxetex,ifluatex}
-\usepackage{unicode-math}
+\usepackage[mathit=sym]{unicode-math}
 \setmathfont{Latin Modern Math}
 
 % Customize the glue for math to relax the spacing a bit.

--- a/template/eisvogel.latex
+++ b/template/eisvogel.latex
@@ -377,11 +377,7 @@ $endif$
 \usepackage{fontspec}
 \setmainfont{Arial}
 \setsansfont{Arial}
-% \setmathsf{Arial}
 \setmonofont{Noto Sans Mono}
-% \setmathtt{Noto Sans Mono}
-% TODO: Understand the redundancy with the unicode-math font setting above.
-% \setmathrm{Latin Modern Math}
 
 \usepackage{newunicodechar}
 % Use Arial Unicode to display various unicode symbols that might be present

--- a/template/eisvogel.latex
+++ b/template/eisvogel.latex
@@ -384,6 +384,10 @@ $endif$
 \setsansfont{Arial}
 \setmonofont{Noto Sans Mono}
 
+\setmathrm{Latin Modern Math}
+\setmathsf{Arial}
+\setmathtt{Noto Sans Mono}
+
 \usepackage{newunicodechar}
 % Use Arial Unicode to display various unicode symbols that might be present
 \newfontfamily{\fallbackfont}{Arial Unicode MS}[Scale=MatchLowercase]

--- a/template/eisvogel.latex
+++ b/template/eisvogel.latex
@@ -402,9 +402,9 @@ $endif$
 \setmathfont{XITS Math}
 
 % Customize the spacing for math to relax it a bit.
-\thinmuskip=60mu
-\medmuskip=80mu plus 4mu minus 2mu
-\thickmuskip=100mu plus 10mu
+\thinmuskip=6mu
+\medmuskip=8mu plus 4mu minus 2mu
+\thickmuskip=10mu plus 10mu
 
 \defaultfontfeatures{Scale=MatchLowercase}
 \defaultfontfeatures[\rmfamily]{Ligatures=TeX,Scale=1}

--- a/template/eisvogel.latex
+++ b/template/eisvogel.latex
@@ -70,15 +70,8 @@ $endif$
 \setstretch{1.0}
 \usepackage[absolute,overlay]{textpos}
 \usepackage{ifxetex,ifluatex}
-$if(mathspec)$
-  \ifxetex{}
-    \usepackage{mathspec}
-  \else
-    \usepackage{unicode-math}
-  \fi
-$else$
-  \usepackage{unicode-math}
-$endif$
+\usepackage{unicode-math}
+\setmathfont{Latin Modern Math}
 
 \defaultfontfeatures{Scale=MatchLowercase}
 \defaultfontfeatures[\rmfamily]{Ligatures=TeX,Scale=1}

--- a/template/eisvogel.latex
+++ b/template/eisvogel.latex
@@ -385,16 +385,10 @@ $endif$
   skipabove=\parskip,
   nobreak=true]{customcodeblock}
 
-\usepackage{fontspec}
+\usepackage[no-math]{fontspec}
 \setmainfont{Arial}
 \setsansfont{Arial}
-\setmathsf{Arial}
-
 \setmonofont{Noto Sans Mono}
-\setmathtt{Noto Sans Mono}
-
-% TODO: Understand the redundancy with the unicode-math font setting above.
-\setmathrm{Latin Modern Math}
 
 \usepackage{newunicodechar}
 % Use Arial Unicode to display various unicode symbols that might be present

--- a/template/eisvogel.latex
+++ b/template/eisvogel.latex
@@ -385,11 +385,16 @@ $endif$
   skipabove=\parskip,
   nobreak=true]{customcodeblock}
 
-% Pass 'no-math' here to let unicode-math above handle the math fonts.
-\usepackage{fontspec}[no-math]
+\usepackage{fontspec}
 \setmainfont{Arial}
 \setsansfont{Arial}
+\setmathsf{Arial}
+
 \setmonofont{Noto Sans Mono}
+\setmathtt{Noto Sans Mono}
+
+% TODO: Understand the redundancy with the unicode-math font setting above.
+\setmathrm{Latin Modern Math}
 
 \usepackage{newunicodechar}
 % Use Arial Unicode to display various unicode symbols that might be present

--- a/template/eisvogel.latex
+++ b/template/eisvogel.latex
@@ -405,11 +405,10 @@ $endif$
 \usepackage[mathit=sym]{unicode-math}
 \setmathfont{XITS Math}
 
-% Customize the glue for math to relax the spacing a bit.
-% https://www.reddit.com/r/LaTeX/comments/10qdg9s/is_it_possible_to_slightly_increase_all/
-\thinmuskip=6mu
-\medmuskip=8mu plus 4mu minus 6mu
-\thickmuskip=10mu plus 10mu
+% Customize the spacing for math to relax it a bit.
+\setlength{\thinmuskip}{6mu}
+\setlength{\medmuskip}{8mu plus 4mu minus 6mu}
+\setlength{\thickmuskip}{10mu plus 10mu}
 
 \defaultfontfeatures{Scale=MatchLowercase}
 \defaultfontfeatures[\rmfamily]{Ligatures=TeX,Scale=1}

--- a/template/eisvogel.latex
+++ b/template/eisvogel.latex
@@ -385,10 +385,14 @@ $endif$
   skipabove=\parskip,
   nobreak=true]{customcodeblock}
 
-\usepackage[no-math]{fontspec}
+\usepackage{fontspec}
 \setmainfont{Arial}
 \setsansfont{Arial}
+\setmathsf{Arial}
 \setmonofont{Noto Sans Mono}
+\setmathtt{Noto Sans Mono}
+% TODO: Understand the redundancy with the unicode-math font setting above.
+\setmathrm{Latin Modern Math}
 
 \usepackage{newunicodechar}
 % Use Arial Unicode to display various unicode symbols that might be present

--- a/template/eisvogel.latex
+++ b/template/eisvogel.latex
@@ -402,9 +402,9 @@ $endif$
 \setmathfont{XITS Math}
 
 % Customize the spacing for math to relax it a bit.
-\thinmuskip=6mu
-\medmuskip=8mu plus 4mu minus 2mu
-\thickmuskip=10mu plus 10mu
+\thinmuskip=60mu
+\medmuskip=80mu plus 4mu minus 2mu
+\thickmuskip=100mu plus 10mu
 
 \defaultfontfeatures{Scale=MatchLowercase}
 \defaultfontfeatures[\rmfamily]{Ligatures=TeX,Scale=1}

--- a/template/eisvogel.latex
+++ b/template/eisvogel.latex
@@ -393,7 +393,7 @@ $endif$
 % \setmathrm{Latin Modern Math}
 
 \usepackage[mathit=sym]{unicode-math}
-\setmathfont{Latin Modern Math}
+\setmathfont{XITS Math}
 
 \usepackage{newunicodechar}
 % Use Arial Unicode to display various unicode symbols that might be present


### PR DESCRIPTION
This change fixes up a conflict between fontspec and unicode-math, and chooses a better math font.