### PR TITLE
Update release naming conventions to be based on semver

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -184,7 +184,7 @@ if test "${do_gitversion}" == "yes"; then
 	# 4.0-54-gabcd --> tag major-minor with commits (len 3)
 	len=${#dash_hunks[@]}
 	if ! test "${len}" -eq 1 -o "${len}" -eq 3; then
-	    >&2 echo "Malformed git version got: ${raw_version}"
+	    >&2 echo "Malformed Git version got: ${raw_version}"
 	    exit 1
     fi
 

--- a/build.sh
+++ b/build.sh
@@ -232,10 +232,7 @@ if test "${do_gitversion}" == "yes"; then
 
 	extra_pandoc_options+=" --metadata=version:${GIT_VERSION}"
 
-	# Tell the template that this is a prerelease only if there are
-	# no revisions.
-	# The review document 1.2.3-rc.1 with one commit on top is 1.2.3 revision 1.
-	if [ ! -z "${GIT_PRERELEASE}" ] && [ -z "${GIT_REVISION}" ]; then
+	if [ ! -z "${GIT_PRERELEASE}" ]; then
 		extra_pandoc_options+=" --metadata=prerelease:${GIT_PRERELEASE}"
 	fi
 

--- a/build.sh
+++ b/build.sh
@@ -174,62 +174,87 @@ if test "${do_gitversion}" == "yes"; then
 	# TODO: Should we fail if dirty?
 	raw_version="$(git describe --always --tags)"
 	echo "Git version: ${raw_version}"
+	# Trim leading letters like v etc
+	raw_version=$(echo "${raw_version}" | sed -E 's/^[a-zA-Z]*(.*)/\1/')
 	IFS='-' read -r -a dash_hunks <<< "${raw_version}"
 
+	# Assume the tags are based on semantic versioning.
     # Could be one of:
-    # gabcd - commit no tag (len 1)
-   	# 4 --> tag major only (len 1)
-	# 4.0 --> tag major minor (len 1)
-	# 4-54-gabcd --> tag major with commits (len 3)
-	# 4.0-54-gabcd --> tag major-minor with commits (len 3)
+	#   Where $COMMIT is the first few digits of a commit hash
+    # g$COMMIT - commit no tag (len 1)
+	#   Where $VERSION is like v1.2.3
+   	# $VERSION --> at the version $VERSION (len 1)
+	#   Where $PRERELEASE is like rc.1
+	# $VERSION-$PRERELEASE --> at the version $VERSION-$PRERELEASE (len 2)
+	#   Where $REVISION is the number of commits since the last tag (e.g., 54)
+	# $VERSION-$REVISION-g$COMMIT --> version without prerelease tag at a particular commit (len 3)
+	# $VERSION-$PRERELEASE-$REVISION-g$COMMIT --> version with  (len 4)
 	len=${#dash_hunks[@]}
-	if ! test "${len}" -eq 1 -o "${len}" -eq 3; then
-	    >&2 echo "Malformed Git version got: ${raw_version}"
-	    exit 1
-    fi
+	case $len in
+		1)
+			if [ "${dash_hunks[0]:0:1}" == "g" ]; then
+				GIT_VERSION="0"
+				GIT_COMMIT="${dash_hunks[0]:1}"
+			else
+				GIT_VERSION="${dash_hunks[0]}"
+			fi
+			;;
+		2)
+			GIT_VERSION="${dash_hunks[0]}"
+			GIT_PRERELEASE="${dash_hunks[1]}"
+			;;
+		3)
+			if [ "${dash_hunks[2]:0:1}" == "g" ]; then
+				GIT_VERSION="${dash_hunks[0]}"
+				GIT_REVISION="${dash_hunks[1]}"
+				GIT_COMMIT="${dash_hunks[2]:1}"
+			else
+				>&2 echo "Malformed Git version: ${raw_version}"
+				exit 1
+			fi
+			;;
+		4)
+			if [ "${dash_hunks[3]:0:1}" == "g" ]; then
+				GIT_VERSION="${dash_hunks[0]}"
+				GIT_PRERELEASE="${dash_hunks[1]}"
+				GIT_REVISION="${dash_hunks[2]}"
+				GIT_COMMIT="${dash_hunks[3]:1}"
+			else
+				>&2 echo "Malformed Git version: ${raw_version}"
+				exit 1
+			fi
+			;;
+		*)
+	    	>&2 echo "Malformed Git version: ${raw_version}"
+	    	exit 1
+			;;
+	esac
 
-	revision="0"
-	major_minor="${dash_hunks[0]}"
-	if test "${len}" -eq 3; then
-		revision="${dash_hunks[1]}"
+	extra_pandoc_options+=" --metadata=version:${GIT_VERSION}"
+
+	# Tell the template that this is a prerelease only if there are
+	# no revisions.
+	# The review document 1.2.3-rc.1 with one commit on top is 1.2.3 revision 1.
+	if [ ! -z "${GIT_PRERELEASE}" ] && [ -z "${GIT_REVISION}" ]; then
+		extra_pandoc_options+=" --metadata=prerelease:${GIT_PRERELEASE}"
 	fi
 
-	# Does this even have a major minor, or is it just a commit (8d7046adcf1b) len of 12 no dot char?
-	# Note that in docker image this sha is shorter at 7 chars for some reason.
-	if grep -qv '\.' <<< "${major_minor}"; then
-		if test ${#major_minor} -ge 7; then
-
-			# it's a commit
-			major_minor="0.0"
-			revision="$(git rev-list --count HEAD)"
-		else
-			# it's a major with no minor
-			major_minor="${major_minor}"
-		fi
-	fi
-
-	# Before scrubbing, grab the first character from 'major_minor'
-	first_char=${major_minor:0:1}
-
-	# scrub any leading non-numerical arguments from major_minor, ie v4.0, scrub any other nonsense as well
-	major_minor="$(tr -d "[:alpha:]" <<< "${major_minor}")"
-
-	extra_pandoc_options+=" --metadata=version:${major_minor}"
-
-	# Revision 0 = no revision
-	if [ "${revision}" -ne "0" ]; then
-		extra_pandoc_options+=" --metadata=revision:${revision}"
+	# Omit the revision if there isn't one (i.e., we are at straight-up Version)
+	if [ ! -z "${GIT_REVISION}" ]; then
+		extra_pandoc_options+=" --metadata=revision:${GIT_REVISION}"
+	elif [ ! -z "${GIT_COMMIT}" ]; then
+		extra_pandoc_options+=" --metadata=revision:${GIT_COMMIT}"
 	fi
 
 	# Do we set document status based on git version?
 	if [ "${do_gitstatus}" == "yes" ]; then
-		# If revision is 0 and the first character of the tag is 'p' (for Published)
-		if [ "${revision}" == "0" ] && [ "${first_char}" == "p" ]; then
+		# If revision is 0 and this is not some kind of prerelease
+		if [ -z "${GIT_REVISION}" ] && [ -z "${GIT_PRERELEASE}" ]; then
 			status="Published"
-		# If revision is 0 and the first character of the tag is 'r' (for Review)
-		elif [ "${revision}" == "0" ] && [ "${first_char}" == "r" ]; then
+		# If revision is 0 and this is some kind of prerelease
+		elif [ -z "${GIT_REVISION}" ] && [ ! -z "${GIT_PRERELEASE}" ]; then
 			status="Review"
-		# Revision is not 0, or the tag doesn't begin with a p or an r.
+		# Everything else is a draft
 		else
 			status="Draft"
 		fi
@@ -253,8 +278,18 @@ echo "use table rules: ${table_rules}"
 echo "make block quotes Informative Text: ${block_quotes_are_informative_text}"
 if test "${do_gitversion}" == "yes"; then
 	echo "Git Generated Document Version Information"
-	echo "    version: ${major_minor}"
-	echo "    revision: ${revision}"
+	if [ ! -z "${GIT_VERSION}" ]; then
+		echo "    version: ${GIT_VERSION}"
+	fi
+	if [ ! -z "${GIT_PRERELEASE}" ]; then
+		echo "    prerelease: ${GIT_PRERELEASE}"
+	fi
+	if [ ! -z "${GIT_REVISION}" ]; then
+		echo "    revision: ${GIT_REVISION}"
+	fi
+	if [ ! -z "${GIT_COMMIT}" ]; then
+		echo "    commit: ${GIT_COMMIT}"
+	fi
 	if [ "${do_gitstatus}" == "yes" ]; then
 		echo "    status: ${status}"
 	fi
@@ -520,7 +555,7 @@ fi
 # Generate the docx output
 if [ -n "${docx_output}" ]; then
 	# Prepare the title-page for the docx version.
-	SUBTITLE="Version ${major_minor:-${DATE}}, Revision ${revision:-0}"
+	SUBTITLE="Version ${GIT_VERSION:-${DATE}}, Revision ${GIT_REVISION:-0}"
 	# Prefix the document with a Word page-break, since Pandoc doesn't do docx
 	# title pages.
 	cat <<- 'EOF' > "${build_dir}/${input_file}.prefixed"

--- a/guide.md
+++ b/guide.md
@@ -971,13 +971,13 @@ documents in Markdown:
 1.  Upload an initial document with some placeholder version. Depending on how you have your
     GitHub actions set up, this may trigger a "TCG Review" render that you never use. That
     is OK.
-    1.  For a brand-new document, tag (GitHub Release) an early version as `0.0.1-alpha` or similar.
+    1.  For a brand-new document, tag (GitHub Release) an early version as `0.0.0` or similar.
     2.  For a migration of an existing document, tag an early version based on the original
-        document's current version (e.g., `1.23.4-migration` for the initial migration based
+        document's current version (e.g., `1.23.4-alpha` for the initial migration based
         on a Word document that was published as version 1.23.4).
 2.  Work on the document by sending pull requests. Each commit on main will increment the
-    revision number. So the first few PRs after `0.0.1-alpha` will be called "0.0.1 Revision 1",
-    "0.0.1 Revision 2", and so on.
+    revision number. So the first few PRs after `1.23.4-alpha` will be called "1.23.4 alpha Revision 1",
+    "0.0.1 alpha Revision 2", and so on.
 3.  Reach the point where you might like to ballot the document. Create a "release candidate",
     by creating a GitHub release called (target version)-rc.1. For example, if the next version
     of the doc you'd like to publish will be 1.23.5, release `1.23.5-rc.1`. This is the
@@ -997,7 +997,7 @@ documents in Markdown:
 
 ::: Note :::
 If the spec is not rendered as part of a release, it will always be
-a draft, of some revision on top of the latest released version number.
+a draft, of some revision on top of the latest released version.
 ::::::::::::
 
 ### Suppressing Git Version Parsing

--- a/guide.md
+++ b/guide.md
@@ -977,7 +977,7 @@ documents in Markdown:
         on a Word document that was published as version 1.23.4).
 2.  Work on the document by sending pull requests. Each commit on main will increment the
     revision number. So the first few PRs after `1.23.4-alpha` will be called "1.23.4 alpha Revision 1",
-    "0.0.1 alpha Revision 2", and so on.
+    "1.23.4 alpha Revision 2", and so on.
 3.  Reach the point where you might like to ballot the document. Create a "release candidate",
     by creating a GitHub release called (target version)-rc.1. For example, if the next version
     of the doc you'd like to publish will be 1.23.5, release `1.23.5-rc.1`. This is the

--- a/guide.md
+++ b/guide.md
@@ -948,14 +948,52 @@ documents rendered as part of a [release](#sec:running-on-release) with a suppor
 
 ### Conventions for Release Naming {#sec:release-conventions}
 
-The tooling expects the following conventions for tagging your releases:
+This tooling assumes a usage of [Semantic Versioning](https://semver.org) (aka semver)
+or similar in how you name your doc releases. It is recommended to use MAJOR.MINOR.PATCH,
+but certain legacy documents may prefer MAJOR.MINOR or even just MAJOR. It is not
+recommended to treat version numbers as decimal values (e.g., 0.01; 0.99 where the next
+version can only be 1.00).
 
-* `vX.Y` indicates a regular draft of version X.Y.
-* `vX.Y.Z` indicates a regular draft of version X.Y.Z.
-* `rX.Y` indicates a review draft of version X.Y.
-* `rX.Y` indicates a review draft of version X.Y.Z.
-* `pX.Y` indicates a published version X.Y.
-* `pX.Y.Z` indicates a published version X.Y.Z.
+The TCG Pandoc tools expects tags chosen for releases to look something like:
+
+* `X.Y` for the published version X.Y. This version is rendered as a "final" doc.
+* `X.Y-rc.1` for the first release candidate for version X.Y. Actual X.Y may come later
+  and supercedes X.Y-rc.1 in value. This release candidate is styled as a "TCG Review" doc.
+  * `rc.1` can be any "prerelease" string. The only real rule is that it doesn't have dashes
+    in it.
+
+If you wish, you can prefix the version with a letter (like `vX.Y`). These letters will
+be trimmed off the front of the tag during build.
+
+Here is a recommended basic workflow for workgroups using GitHub to manage their
+documents in Markdown:
+
+1.  Upload an initial document with some placeholder version. Depending on how you have your
+    GitHub actions set up, this may trigger a "TCG Review" render that you never use. That
+    is OK.
+    1.  For a brand-new document, tag (GitHub Release) an early version as `0.0.1-alpha` or similar.
+    2.  For a migration of an existing document, tag an early version based on the original
+        document's current version (e.g., `1.23.4-migration` for the initial migration based
+        on a Word document that was published as version 1.23.4).
+2.  Work on the document by sending pull requests. Each commit on main will increment the
+    revision number. So the first few PRs after `0.0.1-alpha` will be called "0.0.1 Revision 1",
+    "0.0.1 Revision 2", and so on.
+3.  Reach the point where you might like to ballot the document. Create a "release candidate",
+    by creating a GitHub release called (target version)-rc.1. For example, if the next version
+    of the doc you'd like to publish will be 1.23.5, release `1.23.5-rc.1`. This is the
+    first release candidate. Hopefully it's the only one. This will result in the creation of
+    a "Review" document marked rc.1.
+4.  Ballot the release candidate using the normal TCG process. Send along the "Review" document
+    created by GitHub during the previous step.
+5.  If more iterations are needed,
+    1.  Work on them as in (2) above. So the next few drafts will be called "1.23.5 rc.1 Revision 1",
+    "1.23.5 rc.1 Revision 2", and so on.
+    2.  Release another release candidate marked rc.2, rc.3, etc.
+6.  When the document is approved for public review, send out the release candidate that got
+    approved.
+7.  When it comes time for final publication, release just 1.23.5. This will trigger a render
+    of a "Final" styled document. Note that according to the rules of semver, 1.23.5 is higher
+    than 1.23.5-rc.1.
 
 ::: Note :::
 If the spec is not rendered as part of a release, it will always be

--- a/template/tcg.tex
+++ b/template/tcg.tex
@@ -480,6 +480,10 @@ $endif$
     \hskip 0.25em | \hskip 0.25em 
     Version $version$
     $endif$
+    $if(prerelease)$
+    \hskip 0.25em | \hskip 0.25em 
+    $prerelease$
+    $endif$
     $if(revision)$
     \hskip 0.25em | \hskip 0.25em 
     Revision $revision$
@@ -685,18 +689,21 @@ $endif$
     \vskip 1.5em
     Contact: \hyperlink{mailto:admin@trustedcomputinggroup.org}{admin@trustedcomputinggroup.org}
     \vskip 1.5em
-    \ifthenelse{\equal{\detokenize{$status$}}{\detokenize{Review}}}
+    \ifthenelse{\equal{\detokenize{$status$}}{\detokenize{Published}}}
+    {}
     {
-      \textit{This document is an intermediate draft for comment only and is subject to change without notice. Readers should not design products based on this document.}
-      \vskip 1.5em
-
-      \LARGE \textbf{TCG Public Review}\\
+      \small \textit{This document is an intermediate draft for comment only and is subject to change without notice. Readers should not design products based on this document.}\\
     }
-    {
+    \vskip 1.5em
+    $if(prerelease)$
+      $if(status)$
+      \LARGE \textbf{TCG $status$ ($prerelease$)}\\
+      $endif$
+    $else$
       $if(status)$
       \LARGE \textbf{TCG $status$}\\
       $endif$
-    }
+    $endif$
   \end{textblock*}
   \begin{textblock*}{2cm}(2cm,10.8cm)
   $if(type)$


### PR DESCRIPTION
Semver is a better system than "grab the first character from the tag and guess what type it is".