### PR TITLE
remove key words and statement types from example doc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -149,7 +149,7 @@ RUN npm install --global --unsafe-perm puppeteer@21.7.0 imgur@2.3.0 mermaid-filt
 ENV PATH="${PATH}:/usr/local/texlive/bin/aarch64-linux:/usr/local/texlive/bin/x86_64-linux"
 
 # Packages that are needed despite not being used explicitly by the template:
-# catchfile, fancyvrb, footmisc, hardwrap, lineno, ltablex, latexmk, needspace, pgf, zref
+# bigfoot, catchfile, fancyvrb, footmisc, hardwrap, lineno, ltablex, latexmk, needspace, pgf, zref
 RUN tlmgr update --self && tlmgr install \
     accsupp \
     adjustbox \
@@ -159,6 +159,7 @@ RUN tlmgr update --self && tlmgr install \
     adjustbox \
     anyfontsize \
     appendix \
+    bigfoot \
     bookmark \
     booktabs \
     caption \

--- a/guide.tcg
+++ b/guide.tcg
@@ -40,33 +40,6 @@ and brands contained herein are the property of their respective owners.
 
 ---
 
-# Document Style
-
-**Key Words**
-
-The key words "MUST," "MUST NOT," "REQUIRED," "SHALL," "SHALL NOT," "SHOULD,"
-"SHOULD NOT," "RECOMMENDED," "MAY," and "OPTIONAL" in this document's normative
-statements are to be interpreted as described in
-[RFC 2119: Key words for use in RFCs to Indicate Requirement Levels](https://www.ietf.org/rfc/rfc2119.txt).
-
-**Statement Type**
-
-Please note an important distinction between different sections of text
-throughout this document. There are two distinctive kinds of text: _informative
-comments_ and _normative statements_. Because most of the text in this
-specification will be of the kind _normative statements_, the authors have
-informally defined it as the default and, as such, have specifically called out
-text of the kind _informative comment_. They have done this by flagging the
-beginning and end of each informative comment and highlighting its text in gray.
-This means that unless text is specifically marked as of the kind _informative
-comment_, it can be considered a _normative statement_.
-
-EXAMPLE:
-
-::: Informative ::::
-Reach out to <admin@trustedcomputinggroup> with any questions about this document.
-::::::::::::::::::::
-
 \tableofcontents
 
 \listoftables


### PR DESCRIPTION
Fixes #143

The [template repository](https://github.com/trustedcomputinggroup/specification-example) is where this boilerplate lives now. So we don't have to keep it in the example doc, which as Monty points out in #143 is a guidance doc which shouldn't have those parts.