### PR TITLE
Update dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.3-labs
-ARG BASE=debian:bookworm-20240110-slim
+ARG BASE=debian:bookworm-20240812-slim
 FROM ${BASE} as build-pandoc
 
 WORKDIR /usr/src/pandoc
@@ -13,8 +13,8 @@ RUN apt update && apt install -y \
     zlib1g \
     zlib1g-dev
 
-ENV PANDOC_CLI_VERSION=3.1.12.2
-ENV PANDOC_CROSSREF_VERSION=0.3.17.0
+ENV PANDOC_CLI_VERSION=3.3
+ENV PANDOC_CROSSREF_VERSION=0.3.17.1
 
 RUN cabal update && \
     cabal install -j --only-dependencies \
@@ -143,7 +143,7 @@ RUN apt install -y \
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true \
     PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
 
-RUN npm install --global --unsafe-perm puppeteer@21.7.0 imgur@2.3.0 mermaid-filter@1.4.7 typescript@5.3.3 pandiff@0.6.0
+RUN npm install --global --unsafe-perm puppeteer@23.2.1 imgur@2.4.2 mermaid-filter@1.4.7 typescript@5.5.4 pandiff@0.6.0
 
 # Lazy: Just put both possible texlive paths into the path. Only one will get populated.
 ENV PATH="${PATH}:/usr/local/texlive/bin/aarch64-linux:/usr/local/texlive/bin/x86_64-linux"
@@ -216,7 +216,7 @@ RUN apt install -y \
     xorg \
     xvfb
 
-ENV DRAWIO_RELEASE=23.1.5
+ENV DRAWIO_RELEASE=24.7.8
 
 # TARGETPLATFORM is linux/arm64 or linux/amd64. The release for amd64 is called drawio-amd64-23.1.5.deb.
 RUN export DRAWIO_DEB=drawio-${TARGETPLATFORM#linux/}-${DRAWIO_RELEASE}.deb && \

--- a/build.sh
+++ b/build.sh
@@ -375,12 +375,15 @@ fi
 
 # There are some configuration dependencies required for Mermaid.
 # They have to be in the current directory.
+# --disable-gpu is added here based on:
+# https://github.com/puppeteer/puppeteer/issues/11640
 cat <<- EOF > ./.puppeteer.json
 {
 	"executablePath": "$browser",
 	"args": [
 		"--no-sandbox",
-		"--disable-setuid-sandbox"
+		"--disable-setuid-sandbox",
+		"--disable-gpu"
 	]
 }
 EOF

--- a/template/tcg.tex
+++ b/template/tcg.tex
@@ -143,6 +143,20 @@ $if(logo)$
 \usepackage{rotating}
 $endif$
 
+% https://github.com/Wandmalfarbe/pandoc-latex-template/issues/391
+\makeatletter
+\newsavebox\pandoc@box
+\newcommand*\pandocbounded[1]{% scales image to fit in text height/width
+  \sbox\pandoc@box{#1}%
+  \Gscale@div\@tempa{\textheight}{\dimexpr\ht\pandoc@box+\dp\pandoc@box\relax}%
+  \Gscale@div\@tempb{\linewidth}{\wd\pandoc@box}%
+  \ifdim\@tempb\p@<\@tempa\p@\let\@tempa\@tempb\fi% select the smaller of both
+  \ifdim\@tempa\p@<\p@\scalebox{\@tempa}{\usebox\pandoc@box}%
+  \else\usebox{\pandoc@box}%
+  \fi%
+}
+\makeatother
+
 $if(highlighting-macros)$
 $highlighting-macros$
 


### PR DESCRIPTION
This change updates the dependency versions of:

- debian-bookworm
- pandoc
- pandoc-crossref
- puppeteer
- imgur
- mermaid-filter
- typescript
- drawio

It also resolves an issue seen running on newer Chromium browsers (>126 or so) where the browser hangs. See
https://github.com/puppeteer/puppeteer/issues/11640 for more information about this issue.

Because of the update to pandoc 3.2.1, this change also updates the TCG LaTeX template to provide the new required `\pandocbounded` macro. It doesn't appear to have any actual effect for images in docs.