### PR TITLE
Always create a tmp directory and copy everything into it

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -186,11 +186,11 @@ if [ "${PDF_ENGINE}" != "xelatex" -a "${PDF_ENGINE}" != "lualatex" ]; then
 	exit 1
 fi
 
-# Set up the build directory, either tmp or build in pwd.
+# Set up the build directory.
 readonly BUILD_DIR="/tmp/tcg.pandoc"
 readonly SOURCE_DIR=$(pwd)
 mkdir -p "${BUILD_DIR}"
-# Copy everything into the build directory, then change to that directory.
+# Copy everything into the build directory, then cd to that directory.
 # This will allow us to manipulate the Git state without side effects
 # to callers of docker_run.
 cp -r . "${BUILD_DIR}"


### PR DESCRIPTION
This change prepares for a future change that uses git history to render diffs. To avoid messing up the bind-mounted current directory (docker_run), copy everything in the current directory to the build directory, then copy what we need back.

This change means that notmp is no longer supported.