### PR TITLE
crop drawio conversions

### DIFF
--- a/filter/convert-images.lua
+++ b/filter/convert-images.lua
@@ -43,7 +43,7 @@ end
 -- https://github.com/jgraph/drawio-desktop/issues/249
 function drawio(source, dest)
     print(string.format('converting %s using drawio...', source))
-    if not runCommandSuppressOutput(string.format("xvfb-run -a drawio -x -f pdf -o %s %s --no-sandbox 2>&1", dest, source)) then
+    if not runCommandSuppressOutput(string.format("xvfb-run -a drawio -x -f pdf --crop -o %s %s --no-sandbox 2>&1", dest, source)) then
         print(string.format('failed to convert %s to %s using drawio, falling back to letting latex try to pick it up', source, dest))
         return false
     end

--- a/sample.drawio.svg
+++ b/sample.drawio.svg
@@ -1,4 +1,4 @@
-<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="225px" height="231px" viewBox="-0.5 -0.5 225 231" content="&lt;mxfile&gt;&lt;diagram id=&quot;ZsT7yVSXCH5zRSQvvg-b&quot; name=&quot;Page-1&quot;&gt;rVZLb6MwEP41XFc8QpJrSfo4dNVIqbTdo4MnYNVgZEwg++vXDjZgIG12lVNmPo/HM988iBNssuaZoyL9yTBQx3dx4wRbx/e95dqTPwo5d0jQIgknWGM9sCd/QIOuRiuCobQMBWNUkMIGY5bnEAsLQ5yz2jY7Mmq/WqBEv+j2wD5GFCZmvwgWaYuuw4H1C5AkNS97rj7JkDHWQJkizOoBFDw6wYYzJlopazZAFXuGl/be05XTLjAOubjlgt9eOCFa6dx2nMVQSoKedITibNKWwRZKLIxJVKdEwL5AsYJrWW2JpSKjUvOkeEDxZ8JZleO3SlCSg8anUerAT8AFNANIR/0MLAPBz9JEnxoCTQuttF739fCMTTqoxVJjSLdA0nnuWZKCJmqetGBCmuMvqVAJSyFRwjYykHTWoVcZjc+SHQw8uIFTRSfg18N3JJft2HjhfQj31gub8eWU8eUM4es7EL6YIXzEJOT4QU22IpOisiSxokAgLqbwgE1oiPgYyL+l7P4ItbZVubtGORsll+F/DJXBLaX21y6adW8HnMj8gWvwamVKVvEYrCmV2SQgrB4EnMCX1RtUJ5ypjsE4UCTIyd5vcyXTL+wYkfF2zRGE9jiG/qjqbTb61nAfjRwtXNvRYjVy1HIwcXTpoC7tm5oqnDTVO5Sim2TeD22LMDpGKDHIm5y6ft57fGr5XrNbLVMOX3uV4DCo0UR8s0dQWbSfxiNpAN9nRwSjpXzjTvbG3fI/O2I1U85GTFgRCrSJoCTJ1X6QeauxjFS+RH7sH/RBRjBW1yMOcqeiw8WVmt1CdeEl5DBywq3yVQlm9u5l/3D2CRtGmRr3nKndHB0JpSPoHut5ZXM/8z2cm//g35mXav//pJ27/m9e8PgX&lt;/diagram&gt;&lt;/mxfile&gt;">
+<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="231px" height="231px" viewBox="-0.5 -0.5 231 231" content="&lt;mxfile&gt;&lt;diagram id=&quot;ZsT7yVSXCH5zRSQvvg-b&quot; name=&quot;Page-1&quot;&gt;rVZLc9owEP41vnb8wIYeAyTpoZ0wQ2aaHoW12JrIlkeWwfTXV0IStmyTkA4XZvfTarX77cN40aponzmq8l8MA/VCH7detPbCMJ4v5K8CThpIkkQDGSdYQ0EHbMlfMKBv0IZgqB1DwRgVpHLBlJUlpMLBEOfs6JrtGXVfrVBmXvQ7YJsiCiOz3wSLXKOLuGf9A0iW25cD35wUyBoboM4RZsceFD160YozJrRUtCugijvLi773dOX0EhiHUtxyIdQXDog2JrcNZynUkqAnE6E42bRlsJUSK2uyPOZEwLZCqYKPstYSy0VBpRZIcYfS94yzpsQvjaCkBIOPozSBH4ALaHuQifoZWAGCn6SJObUEmg4K5kY/dvUIrE3eq0ViMGRaILt47liSgiFqmrRoRJoXJlSohKWQKWG9tJB0dkGvMpqeJDsYeHQDp4pOwD93n5Fc67EJ4vsQHnwfMJ6MGU8mCF/cgfDZBOEDJqHED2qyFZkU1TVJFQUCcTGGe2xCS8RbT/4jZf9bbLS1yt23yskqpQz/ra/0bim1u3bWnHsb4ETmD9yAVytTs4an4EypzCYD4fQg4Aw+rF6vOvFEdSzGgSJBDu5+myqZeWHDiIz30hxR7DZHHA6qrrMxt/r7aOBo5ruOZvOBI83ByNG5gy5p39RU8aipXqEWl0nm3dBqhNEhQolFXuTUdfPe4WPL1yO71TLn8LFXCfaDGkzEJ3sE1ZX+NO5JC/g+OyIarIgbd3Iw7Jb/2RHziXK2YsSKUKBLBCVZqfaDzFuN5VLlS+TH/sEcFARjdX3JQe5UtDu7UrNbqS48hxwvvXitfDWC2b173j+cvcOKUabGvWRqNy/3hNIBdI/1PHe5n/geTs1/9HXmpdr9P9Fz1/3Jix7/AQ==&lt;/diagram&gt;&lt;/mxfile&gt;">
     <defs/>
     <g>
         <rect x="0" y="160" width="120" height="60" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
@@ -19,12 +19,12 @@
                 </text>
             </switch>
         </g>
-        <path d="M 164 165 C 164 156.72 177.43 150 194 150 C 201.96 150 209.59 151.58 215.21 154.39 C 220.84 157.21 224 161.02 224 165 L 224 215 C 224 223.28 210.57 230 194 230 C 177.43 230 164 223.28 164 215 Z" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-        <path d="M 224 165 C 224 173.28 210.57 180 194 180 C 177.43 180 164 173.28 164 165" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 170 165 C 170 156.72 183.43 150 200 150 C 207.96 150 215.59 151.58 221.21 154.39 C 226.84 157.21 230 161.02 230 165 L 230 215 C 230 223.28 216.57 230 200 230 C 183.43 230 170 223.28 170 215 Z" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 230 165 C 230 173.28 216.57 180 200 180 C 183.43 180 170 173.28 170 165" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
                 <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 58px; height: 1px; padding-top: 203px; margin-left: 165px;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 58px; height: 1px; padding-top: 203px; margin-left: 171px;">
                         <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
                             <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
                                 <b>
@@ -34,14 +34,14 @@
                         </div>
                     </div>
                 </foreignObject>
-                <text x="194" y="206" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                <text x="200" y="206" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
                     DB
                 </text>
             </switch>
         </g>
-        <path d="M 126.37 190 L 157.63 190" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 126.37 190 L 163.63 190" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
         <path d="M 121.12 190 L 128.12 186.5 L 126.37 190 L 128.12 193.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
-        <path d="M 162.88 190 L 155.88 193.5 L 157.63 190 L 155.88 186.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 168.88 190 L 161.88 193.5 L 163.63 190 L 161.88 186.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
         <rect x="10" y="0" width="120" height="120" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>


### PR DESCRIPTION
drawio needs `--crop` now in order to trim diagrams to their actual size