### PR TITLE
Base files on source branch in PR workflows

### DIFF
--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -49,7 +49,6 @@ jobs:
           echo output filename: ${filename}
 
       - name: Checkout
-        if: inputs.workflow != 'pr'
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.revision }}

--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -48,17 +48,6 @@ jobs:
           echo OUTPUT_FILENAME="${filename}" >> "$GITHUB_OUTPUT"
           echo output filename: ${filename}
 
-      # For pull requests, check out the head ref of the source branch from the source repo.
-      - name: Checkout
-        if: inputs.workflow == 'pr'
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          fetch-depth: 0
-          fetch-tags: true
-      # For other workflows, check out the requested revision (which defaults to
-      # head of the default branch).
       - name: Checkout
         if: inputs.workflow != 'pr'
         uses: actions/checkout@v4

--- a/build.sh
+++ b/build.sh
@@ -246,17 +246,13 @@ fi
 EXTRA_PANDOC_OPTIONS=""
 if test "${DO_GITVERSION}" == "yes"; then
 	if [ ! -z "${PR_NUMBER}" ] && $(git rev-parse HEAD^2 >/dev/null 2>/dev/null); then
-		# For PR workflows, check out the right parent so that filenames etc.
-		# are based on the most recent commit on the source branch.
+		# For PR workflows, base the version info on the right parent.
 		# In the context of a GitHub pull request, HEAD is a merge commit where
 		# parent1 (HEAD^1) is the target branch and parent2 (HEAD~2) is the source
-		parent1=$(git rev-parse HEAD^1 2>/dev/null)
-		parent2=$(git rev-parse HEAD^2 2>/dev/null)
-		echo "Merge commit detected:"
-		echo "1: $parent1"
-		echo "2: $parent2"
-		echo "Checking out $parent2."
-		git checkout $parent2
+		GIT_COMMIT=$(git rev-parse --short HEAD^2)
+	else
+		# Otherwise, base the version info on HEAD.
+		GIT_COMMIT=$(git rev-parse --short HEAD)
 	fi
 
 	# TODO: Should we fail if dirty?
@@ -277,7 +273,6 @@ if test "${DO_GITVERSION}" == "yes"; then
 	#   Where $REVISION is the number of commits since the last tag (e.g., 54)
 	# $VERSION-$REVISION-g$COMMIT --> version without prerelease tag at a particular commit (len 3)
 	# $VERSION-$PRERELEASE-$REVISION-g$COMMIT --> version with  (len 4)
-	GIT_COMMIT=$(git rev-parse --short HEAD)
 	len=${#dash_hunks[@]}
 	case $len in
 		1)

--- a/build.sh
+++ b/build.sh
@@ -245,6 +245,17 @@ fi
 # figure out git version and revision if needed.
 EXTRA_PANDOC_OPTIONS=""
 if test "${DO_GITVERSION}" == "yes"; then
+	# If HEAD is a merge commit, go to the first parent.
+	if $(git rev-parse HEAD^2 >/dev/null 2>/dev/null); then
+		parent1=$(git rev-parse HEAD^1 2>/dev/null)
+		parent2=$(git rev-parse HEAD^2 2>/dev/null)
+		echo "Merge commit detected:"
+		echo "1: $parent1"
+		echo "2: $parent2"
+		echo "Checking out $parent1."
+		git checkout $parent1
+	fi
+
 	# TODO: Should we fail if dirty?
 	raw_version="$(git describe --always --tags)"
 	echo "Git version: ${raw_version}"

--- a/build.sh
+++ b/build.sh
@@ -245,15 +245,18 @@ fi
 # figure out git version and revision if needed.
 EXTRA_PANDOC_OPTIONS=""
 if test "${DO_GITVERSION}" == "yes"; then
-	# If HEAD is a merge commit, go to the first parent.
-	if $(git rev-parse HEAD^2 >/dev/null 2>/dev/null); then
+	if [ ! -z "${PR_NUMBER}" ] && $(git rev-parse HEAD^2 >/dev/null 2>/dev/null); then
+		# For PR workflows, check out the right parent so that filenames etc.
+		# are based on the most recent commit on the source branch.
+		# In the context of a GitHub pull request, HEAD is a merge commit where
+		# parent1 (HEAD^1) is the target branch and parent2 (HEAD~2) is the source
 		parent1=$(git rev-parse HEAD^1 2>/dev/null)
 		parent2=$(git rev-parse HEAD^2 2>/dev/null)
 		echo "Merge commit detected:"
 		echo "1: $parent1"
 		echo "2: $parent2"
-		echo "Checking out $parent1."
-		git checkout $parent1
+		echo "Checking out $parent2."
+		git checkout $parent2
 	fi
 
 	# TODO: Should we fail if dirty?


### PR DESCRIPTION
This change undoes some earlier work to try to check out the source branch in some way. This breaks on e.g., private forks.

Instead, we "live with" the fact that in the context of a PR, HEAD is a merge commit. In this context, the source branch is HEAD^2 (parent 2) and we can just grab that commit hash and proceed.