### PR TITLE
consistently don't list or number tables without a caption

### DIFF
--- a/filter/tabularx.lua
+++ b/filter/tabularx.lua
@@ -254,9 +254,9 @@ function Table(tbl)
 
         -- .unnumbered .unlisted is the traditional pair of classes Pandoc uses
         -- to omit something from the TOC. Let's keep that tradition alive.
-        -- Also, omit tables with no caption or identifier as well.
+        -- Also, omit tables with no caption as well.
         if (tbl.classes:find('unnumbered') and tbl.classes:find('unlisted'))
-            or (caption == '' and tbl.identifier == '') then
+            or (caption == '') then
             numbered = false
         end
 
@@ -270,7 +270,7 @@ function Table(tbl)
         -- Undo this by decrementing the counter before starting the uncounted table.
         -- Decrementing the counter after the table can cause links in the list of tables to
         -- mistakenly point to the wrong table.
-        if not numbered and escaped_caption ~= '' then
+        if not numbered then
             latex_code = latex_code .. '\\addtocounter{table}{-1}\n'
         end
 


### PR DESCRIPTION
There was a bug in the "should we not number this table" logic:

- The use of `caption` and `caption*` (controls links in list of tables) wasn't always consistent with the `\addtocounter{table}{-1}` workaround (undoes the incrementation of the counter)
- As a result, many tables that shouldn't have been numbered (in the TPM spec) were getting numbered

This change updates the logic to be more clear:

A table is not numbered, and not included in the list of tables, if:

- `.unnumbered .unlisted` (traditional way to omit stuff from the TOC) OR
- there is no caption

Edge case corollary: a table that is `.unnumbered .unlisted` should not be cross-referenced.

Fixes #194