### PR TITLE
Add citations feature (+ backmatter).

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -51,7 +51,7 @@ print_usage() {
 	echo "Miscellaneous"
 	echo "  --resourcedir=dir: Set the resource directory, defaults to root for pandoc containers"
 	echo "  --gitversion: legacy flag, no effect (default starting with 0.9.0)"
-    echo "  --gitstatus: legacy flag, no effect (default starting with 0.9.0)"
+	echo "  --gitstatus: legacy flag, no effect (default starting with 0.9.0)"
 	echo "  --nogitversion: Do not use git to describe the generate document version and revision metadata."
 	echo "  --table_rules: legacy flag, no effect (default starting with 0.9.0)"
 	echo "  --plain_quotes: legacy flag, no effect (default starting with 0.9.0)"
@@ -628,6 +628,7 @@ do_latex() {
 
 	# TODO: https://github.com/TrustedComputingGroup/pandoc/issues/164
 	# highlighting breaks diffing due to the \xxxxTok commands generated during highlighting being fragile.
+	# Citations: https://pandoc.org/MANUAL.html#other-relevant-metadata-fields
 	echo "Generating LaTeX Output"
 	local start=$(date +%s)
 	local cmd=(pandoc
@@ -643,6 +644,7 @@ do_latex() {
 		--lua-filter=landscape-pages.lua
 		--lua-filter=style-fenced-divs.lua
 		--filter=pandoc-crossref
+		--citeproc
 		--lua-filter=tabularx.lua
 		--lua-filter=divide-code-blocks.lua
 		--resource-path=.:/resources
@@ -654,6 +656,8 @@ do_latex() {
 		--metadata=date-english:"'${DATE_ENGLISH}'"
 		--metadata=year:"'${YEAR}'"
 		--metadata=titlepage:true
+		--metadata=link-citations
+		--metadata=link-bibliography
 		--metadata=titlepage-background:/resources/img/cover.png
 		--metadata=crossrefYaml:/resources/filters/pandoc-crossref.yaml
 		--metadata=logo:/resources/img/tcg.png

--- a/template/tcg.tex
+++ b/template/tcg.tex
@@ -209,6 +209,51 @@ $else$
 \setcounter{secnumdepth}{-\maxdimen} % remove section numbering
 $endif$
 
+% For CSL citations/references (bibliography)
+% See: https://github.com/jgm/citeproc/issues/135
+$if(csl-refs)$
+% definitions for citeproc citations
+\NewDocumentCommand\citeproctext{}{}
+\NewDocumentCommand\citeproc{mm}{%
+\begingroup\def\citeproctext{#2}\cite{#1}\endgroup}
+\makeatletter
+% allow citations to break across lines
+\let\@cite@ofmt\@firstofone
+% avoid brackets around text for \cite:
+\def\@biblabel#1{}
+\def\@cite#1#2{{#1\if@tempswa , #2\fi}}
+\makeatother
+\newlength{\cslhangindent}
+\setlength{\cslhangindent}{1.5em}
+\newlength{\csllabelwidth}
+\setlength{\csllabelwidth}{3em}
+\newenvironment{CSLReferences}[2] % #1 hanging-indent, #2 entry-spacing
+{\begin{list}{}{%
+    \setlength{\itemindent}{0pt}
+    \setlength{\leftmargin}{0pt}
+    \setlength{\parsep}{0pt}
+    % turn on hanging indent if param 1 is 1
+    \ifodd #1
+    \setlength{\leftmargin}{\cslhangindent}
+    \setlength{\itemindent}{-1\cslhangindent}
+    \fi
+    % set entry spacing
+    \setlength{\itemsep}{#2\baselineskip}}}
+{\end{list}}
+% \usepackage{calc}
+\newcommand{\CSLBlock}[1]{\hfill\break\parbox[t]{\linewidth}{\strut\ignorespaces#1\strut}}
+\newcommand{\CSLLeftMargin}[1]{\parbox[t]{\csllabelwidth}{\strut#1\strut}}
+\newcommand{\CSLRightInline}[1]{\parbox[t]{\linewidth - \csllabelwidth}{\strut#1\strut}}
+\newcommand{\CSLIndent}[1]{\hspace{\cslhangindent}#1}
+$endif$
+
+% Adjust \paragraph and \subparagraph behavior to be free-standing headings:
+% - By default, \paragraph and \subparagraph are run-in headings
+%   (appear inline with text).
+% - This block ensures they are treated as block-level headings,
+%   appearing on their own line.
+% - Only takes effect if the `block-headings` variable is enabled.
+% - Preserves original behavior for fallback if necessary.
 $if(block-headings)$
 % Make \paragraph and \subparagraph free-standing
 \ifx\paragraph\undefined\else
@@ -726,6 +771,26 @@ $endif$
   \appendix
   \appendixpage
   \addappheadtotoc
+}
+
+% Allow TCG documents to use '\beginbackmatter' to easily mark the transition to the back matter (after the appecndices).
+\newcommand{\beginbackmatter}{
+  \newpage
+  \let\oldsection\section
+  \renewcommand{\section}[1]{%
+    \oldsection*{##1}% Unnumbered section
+    \addcontentsline{toc}{section}{##1}% Add to the ToC
+  }
+  \let\oldsubsection\subsection
+  \renewcommand{\subsection}[1]{%
+    \oldsubsection*{##1}% Unnumbered subsection
+    \addcontentsline{toc}{subsection}{##1}% Add to the ToC
+  }
+  \let\oldsubsubsection\subsubsection
+  \renewcommand{\subsubsection}[1]{%
+    \oldsubsubsection*{##1}% Unnumbered subsubsection
+    \addcontentsline{toc}{subsubsection}{##1}% Add to the ToC
+  }
 }
 
 \newcommand{\coverbg}{/resources/img/bluetop.png}


### PR DESCRIPTION
Fixes #205.

Adds support for citations, and introduces `\beginbackmatter` command to mark back matter sections. This avoids the list of references/citations (bibliography) to be part of the appendices (which is wrong, references/bibliography are no appendix).

You can write something like "The TPM 2.0 architecture [@{cite:tcg-tpm2-architecture}] describes ..." in your Markdown document which results in a clickable link (e.g., "The TPM 2.0 architecture [1] describes ...") to the references/citations list at the
end of the PDF document.

In the YAML front matter you add something like:

```yaml
---
bibliography: citations.yaml
csl: transactions-on-computer-systems.csl
...
```

The `citations.yaml` may look as follows:

```yaml
references:
  - id: "cite:tcg-tpm2-architecture"
    title: "Trusted Platform Module Library - Part 1: Architecture"
    author:
      - family: "(TCG)"
        given: "Trusted Computing Group"
    edition: "Family 2.0, Level 00, Revision 01.83"
    organization: "Trusted Computing Group"
    publisher: "Trusted Computing Group (TCG)"
    series: "TCG Specification"
    issued:
      year: 2024
      month: 1
      day: 25
    url: "https://trustedcomputinggroup.org/resourcetpm-library-specification/"
```

For the back matter, please put the `\beginbackmatter` command in the Markdown source and add the list of references/citations (bibliography) as follows:

```md
\beginbackmatter

# References

::: {#refs}
:::
```