### PR TITLE
Improve SVG conversion.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -240,6 +240,7 @@ RUN tlmgr update --self && tlmgr install \
 RUN apt install -y \
     dbus \
     imagemagick \
+    librsvg2-bin \
     libxss1 \
     openbox \
     wget \

--- a/filter/convert-images.lua
+++ b/filter/convert-images.lua
@@ -59,16 +59,26 @@ function imagemagick(source, dest)
     return true
 end
 
+function svg(source, dest)
+    print(string.format('converting %s using rsvg-convert...', source))
+    if not runCommandSuppressOutput(string.format("rsvg-convert --format=pdf --dpi-x=300 --dpi-y=300 --keep-aspect-ratio --output %s %s 2>&1", dest, source)) then
+        print(string.format('failed to convert %s to %s using rsvg-convert, falling back to letting latex try to pick it up', source, dest))
+        return false
+    end
+    return true
+end
+
 function string:hassuffix(suffix)
-    return self:sub(-#suffix) == suffix
+    return self:sub(-#suffix):lower() == suffix:lower()
 end
 
 function converterFor(filename)
-    if filename:hassuffix('.drawio') or filename:hassuffix('.drawio.svg') then
+    if filename:hassuffix('.drawio') --[[or filename:hassuffix('.drawio.svg')--]] then
         return drawio
-    end
-    if filename:hassuffix('.jpg') or filename:hassuffix('.png') or filename:hassuffix('.svg') then
+    elseif filename:hassuffix('.jpg') or filename:hassuffix('.jpeg') or filename:hassuffix('.png') or filename:hassuffix('.webp') then
         return imagemagick
+    elseif filename:hassuffix('.svg') then
+        return svg
     end
     return nil
 end

--- a/filter/informative-quote-blocks.lua
+++ b/filter/informative-quote-blocks.lua
@@ -13,4 +13,4 @@ function BlockQuote(el)
         pandoc.RawBlock('latex', '\\end{mdframed}')
     }))
     return result
-  end
+end


### PR DESCRIPTION
Fixes #207.

Improved SVG conversion:

* Adapted and extended the `convert-images.lua` script to handle SVG conversions (including `*.drawio.svg`) with `rsvg-convert`, which is faster (and better!?) than using draw.io (which sometimes produces garbage: missing and skewed arrows and elements, wrong overlaps, etc.).

* Added the package `librsvg2-bin` to the Dockerfile (for the tool `rsvg-convert`)

* The `string:hassuffix` function is no longer case-sensitive.

* Added support for image types `jpeg` and `webp`

* Minor indentation fix in `informative-quote-blocks.lua`