### PR TITLE
introduce --autobackmatter

### DIFF
--- a/template/tcg.tex
+++ b/template/tcg.tex
@@ -773,7 +773,7 @@ $endif$
   \addappheadtotoc
 }
 
-% Allow TCG documents to use '\beginbackmatter' to easily mark the transition to the back matter (after the appecndices).
+% Allow TCG documents to use '\beginbackmatter' to easily mark the transition to the back matter (after the appendices).
 \newcommand{\beginbackmatter}{
   \newpage
   \let\oldsection\section


### PR DESCRIPTION
This change introduces a new flag --noautobackmatter, that controls the automatic insertion of the back
matter into a spec so that spec writers don't have to include the following at the end of their specs:

\beginbackmatter

\# References

::: {#refs}
:::

Auto backmatter is enabled by default, but it can be disabled with --noautobackmatter.

The references section is only included if there is a bibliography: tag in the YAML front matter of the markdown file.