### PR TITLE
don't change spacing in 'tight lists'

### DIFF
--- a/template/tcg.tex
+++ b/template/tcg.tex
@@ -192,8 +192,7 @@ $endif$
 \makeatother
 
 \setlength{\emergencystretch}{3em} % prevent overfull lines
-\providecommand{\tightlist}{%
-  \setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
+\providecommand{\tightlist}{}
 $if(numbersections)$
 \setcounter{secnumdepth}{$if(secnumdepth)$$secnumdepth$$else$5$endif$}
 $else$


### PR DESCRIPTION
Pandoc determines certain types of lists to be "tight" (documentation is unclear exactly when). When this happens, the `\tightlist` is invoked.

This PR makes it so that `\tightlist` has no effect.