### PR TITLE
make parskip inside a table the same as outside

### DIFF
--- a/filter/tabularx.lua
+++ b/filter/tabularx.lua
@@ -283,6 +283,7 @@ function Table(tbl)
         -- doesn't get updated in the landscape environment.
         -- This will cause problems with tables inside of tables, but we don't support that.
         latex_code = latex_code .. '\\begin{xltabular}{\\linewidth}{'
+
         --
         -- Specify the columns
         --

--- a/filter/tabularx.lua
+++ b/filter/tabularx.lua
@@ -47,8 +47,8 @@ end
 
 function GetCellCode(cell)
     local cell_code = pandoc.write(pandoc.Pandoc(cell.contents),'latex')
-    -- \\ is not supported inside a cell. Replace it with a double-newline and a parskip.
-    cell_code = cell_code:gsub('\\\\', '\n\n\\tabularparskip')
+    -- \\ is not supported inside a cell. Replace it with a double-newline and a small skip.
+    cell_code = cell_code:gsub('\\\\', '\n\n\\smallskip')
     return cell_code
 end
 

--- a/template/tcg.tex
+++ b/template/tcg.tex
@@ -456,6 +456,8 @@ $endif$
 %
 \setlength{\parindent}{0pt}
 \setlength{\parskip}{6pt plus 2pt minus 1pt}
+\newlength{\tabularparskip}
+\setlength{\tabularparskip}{\parskip}
 \setlength{\emergencystretch}{3em}  % prevent overfull lines
 
 %


### PR DESCRIPTION
xltabular resets the paragraph spacing to 0, which makes multiple paragraphs indistinguishable from wrapped lines. This change recovers the spacing inside the tabular environment based on https://tex.stackexchange.com/questions/279207/why-is-parskip-zero-inside-a-tabular.

Before:

![image](https://github.com/user-attachments/assets/27d12bf5-41e4-465f-b03b-6b210e0fd8d1)


After:

![image](https://github.com/user-attachments/assets/d46a9ad1-3c99-4e19-a8e9-813001fe3f30)
