### PR TITLE
Add filter for handling helper classes.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -771,6 +771,7 @@ do_latex() {
 		--standalone
 		--highlight-style=${SYNTAX_HIGHLIGHT_STYLE}
 		--template=${TEMPLATE_PDF}
+		--lua-filter=render-helpers.lua
 		--lua-filter=convert-diagrams.lua
 		--lua-filter=convert-aasvg.lua
 		--lua-filter=convert-images.lua
@@ -882,6 +883,7 @@ do_docx() {
 	cmd=(pandoc
 		--embed-resources
 		--standalone
+		--lua-filter=render-helpers.lua
 		--lua-filter=convert-diagrams.lua
 		--lua-filter=convert-aasvg.lua
 		--lua-filter=convert-images.lua
@@ -926,6 +928,7 @@ do_html() {
 		--standalone
 		--template=${TEMPLATE_HTML}
 		${HTML_STYLESHEET_ARGS}
+		--lua-filter=render-helpers.lua
 		--lua-filter=convert-diagrams.lua
 		--lua-filter=convert-aasvg.lua
 		--lua-filter=parse-html.lua

--- a/filter/render-helpers.lua
+++ b/filter/render-helpers.lua
@@ -1,0 +1,29 @@
+-- Turn [text]{.btick} into `text`, rendered without changing the font.
+
+backtick_chars =
+{
+    ["latex"] = "\\textasciigrave{}",
+    ["default"] = "`"
+}
+
+function backtick(el)
+  local backtick_char = backtick_chars[FORMAT] or backtick_chars["default"]
+
+  local new_inlines = {}
+
+  table.insert(new_inlines, pandoc.RawInline(FORMAT, backtick_char))
+  for _, inline_el in ipairs(el.content) do
+      table.insert(new_inlines, inline_el)
+  end
+  table.insert(new_inlines, pandoc.RawInline(FORMAT, backtick_char))
+
+  return new_inlines
+end
+
+function Span(el)
+  if el.classes:includes('btick') then
+    return backtick(el)
+  else
+    return el
+  end
+end

--- a/guide.tcg
+++ b/guide.tcg
@@ -1460,6 +1460,16 @@ Carl->>Bob: Goodbye
 Bob->>Alice: Goodbye
 ```
 
+## Helper classes
+
+To wrap a word in backticks that render as normal text, you can use the following syntax:
+
+```md
+[These words]{.btick} are in backticks.
+```
+
+[These words]{.btick} are in backticks.
+
 ## TCG Storage Workgroup Customizations
 
 TCG Storage committee uses command `MethodsOrUID` to render Names of methods and UIDs in \MethodsOrUID{Courier New font}.


### PR DESCRIPTION
- .btick wraps the text in backticks, without changing the font. Compatible with both HTML and PDF output.