### PR TITLE
Fix rsync command to prune stale cache images.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -741,7 +741,7 @@ cp_chown() {
 	local src=$1
 	local dst=$2
 
-	rsync --archive --mkpath --chown="${src_uidgid}" "${src}" "${dst}"
+	rsync --archive --mkpath --delete --chown="${src_uidgid}" "${src}" "${dst}"
 }
 
 # Sync generated files (if any) back to the source directory so they can be cached and speed up future runs.


### PR DESCRIPTION
When a figure is re-rendered, stale versions of the figure are removed from the cache. This change fixes that behavior, which was broken in 5a8f24a.