### PR TITLE
Run some disk usage diagnostics at the start of the build

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,6 +16,14 @@ jobs:
       packages: write
 
     steps:
+      # Debug "No space left on device (os error 28)" issues
+      - name: Check disk usage
+        run: df -h
+      - name: Check sizes of directories in home directory
+        run: du -sh /home/runner/* | sort -h
+      - name: Check sizes of directories in tools cache
+        run: du -sh /opt/hostedtoolcache/* | sort -h
+
       # Login against a Docker registry
       # https://github.com/docker/login-action
       - name: Log into registry


### PR DESCRIPTION
Builds are currently failing with errors like the following from https://github.com/TrustedComputingGroup/pandoc/actions/runs/20356097258:

```
#37 4093.1    Compiling two-face v0.4.5
#37 4174.6 error: failed to build archive at `/tmp/cargo-installMzHv9Q/release/deps/libaz-06a19f8d2b7d0542.rlib`: No space left on device (os error 28)
#37 4174.6 
#37 4174.6 error: could not compile `az` (lib) due to 1 previous error
#37 4174.7 warning: build failed, waiting for other jobs to finish...
#37 4201.3 error: failed to build archive at `/tmp/cargo-installMzHv9Q/release/deps/libtwo_face-e3b123c8f4afbd07.rlib`: No space left on device (os error 28)
#37 4201.3 
#37 4201.3 error: could not compile `two-face` (lib) due to 1 previous error
```

Related to #284