### PR TITLE
[WIP] Add Lua filter to extract Part 3 into JSON.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -8,6 +8,7 @@ DIFFPDF_OUTPUT=""
 DIFFTEX_OUTPUT=""
 DOCX_OUTPUT=""
 HTML_OUTPUT=""
+JSON_OUTPUT=""
 LATEX_OUTPUT=""
 LATEX_OVERRIDE=""
 TYPST_OUTPUT=""
@@ -79,7 +80,7 @@ print_usage() {
 }
 
 
-if ! options=$(getopt --longoptions=help,puppeteer,gitversion,gitstatus,nogitversion,table_rules,plain_quotes,versioned_filenames,pr_number:,pr_repo:,diffbase:,pdf:,diffpdf:,difftex:,diffpdflog:,latex:,latex_override:,typst:,pdflog:,pdf_engine:,template:,template_html:,html_stylesheet:,reference_doc:,docx:,crossref:,html:,resourcedir:,noautobackmatter,csl: --options="" -- "$@"); then
+if ! options=$(getopt --longoptions=help,puppeteer,gitversion,gitstatus,nogitversion,table_rules,plain_quotes,versioned_filenames,pr_number:,pr_repo:,diffbase:,pdf:,diffpdf:,difftex:,diffpdflog:,latex:,latex_override:,typst:,pdflog:,pdf_engine:,template:,template_html:,html_stylesheet:,reference_doc:,docx:,crossref:,html:,json:,resourcedir:,noautobackmatter,csl: --options="" -- "$@"); then
 	echo "Incorrect options provided"
 	print_usage
 	exit 1
@@ -165,6 +166,10 @@ while true; do
 		HTML_OUTPUT="${2}"
 		shift 2
 		;;
+	--json)
+		JSON_OUTPUT="${2}"
+		shift 2
+		;;
 	--template)
 		# TODO: If simultaneous LaTeX and Typst-based PDF generation is required,
 		# then we need separate --template_latex and --template_typst flags.
@@ -248,7 +253,7 @@ if [ ! -e "${INPUT_FILE}" ]; then
 fi
 
 # at least one output must be requested
-if [ -z "${PDF_OUTPUT}${LATEX_OUTPUT}${DOCX_OUTPUT}${HTML_OUTPUT}" ]; then
+if [ -z "${PDF_OUTPUT}${LATEX_OUTPUT}${DOCX_OUTPUT}${HTML_OUTPUT}${JSON_OUTPUT}" ]; then
 	>&2 echo "Expected --pdf, --docx, --html, or --latex option"
 	print_usage
 	exit 1
@@ -495,12 +500,17 @@ if [ "${VERSIONED_FILENAMES}" == "yes" ]; then
 	if [ ! -z "${HTML_OUTPUT}" ]; then
 		HTML_OUTPUT=$(prefix_filename "${version_prefix}" "${HTML_OUTPUT}")
 	fi
+	if [ ! -z "${JSON_OUTPUT}" ]; then
+		JSON_OUTPUT=$(prefix_filename "${version_prefix}" "${JSON_OUTPUT}")
+	fi
+	
 fi
 readonly PDF_OUTPUT
 readonly DIFFPDF_OUTPUT
 readonly DIFFTEX_OUTPUT
 readonly DOCX_OUTPUT
 readonly HTML_OUTPUT
+readonly JSON_OUTPUT
 readonly LATEX_OUTPUT
 readonly PDFLOG_OUTPUT
 readonly DIFFPDFLOG_OUTPUT
@@ -510,6 +520,7 @@ readonly RESOURCE_PATH=".:/resources:${RESOURCE_DIR}"
 echo "Starting Build with"
 echo "file: ${INPUT_FILE}"
 echo "docx: ${DOCX_OUTPUT:-none}"
+echo "json: ${JSON_OUTPUT:-none}"
 echo "pdf: ${PDF_OUTPUT:-none} (engine: ${PDF_ENGINE})"
 echo "diff pdf: ${DIFFPDF_OUTPUT:-none} (engine: ${PDF_ENGINE})"
 echo "latex: ${latex_ouput:-none}"
@@ -1067,6 +1078,30 @@ do_html() {
 	fi
 }
 
+do_json() {
+	local input=$1
+	local output=$2
+	mkdir -p "$(dirname ${output})"
+
+	echo "Generating JSON Output"
+	local start=$(date +%s)
+	local cmd=(pandoc
+		--standalone
+		--lua-filter=part3-command-tables-to-json.lua
+		--data-dir=/resources
+		--from=${FROM}
+		--to=plain
+		--output="'${output}'"
+		"'${input}'")
+	retry 1 "${cmd[@]}"
+	if [ $? -ne 0 ]; then
+		FAILED=true
+		echo "JSON output failed"
+	fi
+	local end=$(date +%s)
+	echo "Elapsed time: $(($end-$start)) seconds"
+}
+
 do_md_fixups "${BUILD_DIR}/${INPUT_FILE}"
 
 # Generate .typ output if either typst or pdf format (using the Typst engine) were requested.
@@ -1117,6 +1152,11 @@ fi
 # Generate the docx output
 if [ -n "${DOCX_OUTPUT}" ]; then
 	do_docx "${BUILD_DIR}/${INPUT_FILE}" "${SOURCE_DIR}/${DOCX_OUTPUT}"
+fi
+
+# Generate the JSON output
+if [ -n "${JSON_OUTPUT}" ]; then
+	do_json "${BUILD_DIR}/${INPUT_FILE}" "${SOURCE_DIR}/${JSON_OUTPUT}"
 fi
 
 # Diffs may fail in some circumstances. Do not fail the entire workflow here.

--- a/filter/part3-command-tables-to-json.lua
+++ b/filter/part3-command-tables-to-json.lua
@@ -1,0 +1,142 @@
+local FieldType = {
+    COMMAND = 1,
+    HANDLE = 2,
+    PARAMETER = 3,
+}
+
+-- Extracts the field type from a cell of the form `========== [TYPE] ==========`
+function getFieldTypeFromSpan(text)
+    -- ^    : Start of string
+    -- %=+  : One or more "=" (the % escapes the = character)
+    -- %s*  : Zero or more spaces
+    -- (.-) : Capture the shortest possible sequence of any characters (the target text)
+    -- %s*  : Zero or more spaces
+    -- %=+  : One or more "="
+    -- $    : End of string
+    local extracted = text:match("^%=+%s*(.-)%s*%=+$")
+
+    if extracted == "Handles" then
+        return FieldType.HANDLE
+    elseif extracted == "Parameters" then
+        return FieldType.PARAMETER
+    else
+        return nil
+    end
+end
+
+-- Extracts a JSON representation of a command table from Part 3.
+--
+-- Must have three columns: Type, Name, and Description
+-- Colspan separators can either be 'Handles' or 'Parameters'
+-- Any fields that appear before the first colspan separator are assumed to be command-code fields.
+function extractCommandFields(tbl)
+    local caption = pandoc.utils.stringify(tbl.caption.long)
+    if #tbl.head.rows ~= 1 then
+        print(string.format("Table '%s' has %d header rows, expected 1", caption, #tbl.head.rows))
+        return nil
+    end
+
+    local header = tbl.head.rows[1]
+
+    if #header.cells ~= 3 then
+        print(string.format("Table '%s' has %d header cells, expected 3", caption, #header.cells))
+        return nil
+    end
+
+    local header_1 = pandoc.utils.stringify(header.cells[1].contents)
+    local header_2 = pandoc.utils.stringify(header.cells[2].contents)
+    local header_3 = pandoc.utils.stringify(header.cells[3].contents)
+
+    if header_1 ~= "Type" or header_2 ~= "Name" or header_3 ~= "Description" then
+        print(string.format("Table '%s' has malformed header cells: '%s', '%s', '%s'; expected 'Type', 'Name' and 'Description'",
+            caption, header_1, header_2, header_3))
+        return nil
+    end
+
+    if #tbl.bodies ~= 1 then
+        print(string.format("Table '%s' has %d bodies, expected 1", caption, #tbl.bodies))
+        return nil
+    end
+
+    local fields = {command_fields = {}, handle_fields = {}, parameter_fields = {}}
+    local current_field_type = FieldType.COMMAND
+
+    for i, row in ipairs(tbl.bodies[1].body) do
+        if #row.cells == 1 then
+            -- We're in a colspan which indicates the type of fields that follow.
+
+            local span_contents = pandoc.utils.stringify(row.cells[1].contents)
+            current_field_type = getFieldTypeFromSpan(span_contents)
+
+            if current_field_type == nil then
+                print(string.format("Table '%s' has malformed span: '%s', expected 'Handles' or 'Parameters'",
+                    caption, span_contents))
+                return nil
+            end
+        elseif #row.cells == 3 then
+            type_cell = pandoc.utils.stringify(row.cells[1].contents)
+            name_cell = pandoc.utils.stringify(row.cells[2].contents)
+            desc_cell = pandoc.utils.stringify(row.cells[3].contents)
+
+            local field = {type = type_cell, name = name_cell, description = desc_cell}
+
+            if current_field_type == FieldType.COMMAND then
+                table.insert(fields.command_fields, field)
+            elseif current_field_type == FieldType.HANDLE then
+                table.insert(fields.handle_fields, field)
+            elseif current_field_type == FieldType.PARAMETER then
+                table.insert(fields.parameter_fields, field)
+            end
+        else
+            print(string.format("Table '%s' row %d has %d columns, expected 1 or 3", caption, i, #row.cells))
+            return nil
+        end
+    end
+
+    return fields
+end
+
+-- Takes a table of entries whose captions are of the form "[Command name] [Command/Response]"
+-- and collates the command and response fields.
+function collateCommandsAndResponses(data_entries)
+    local collated = {}
+
+    for _, table_data in ipairs(data_entries) do
+        local command_name, type = string.match(table_data["caption"], "(%w+) (%w+)")
+        if collated[command_name] == nil then
+            collated[command_name] = {}
+        end
+
+        if type == "Command" then
+            collated[command_name]["command"] = table_data["fields"]
+        elseif type == "Response" then
+            collated[command_name]["response"] = table_data["fields"]
+        else
+            print(string.format("Table '%s' has malformed type, expected 'Command' or 'Response'", table_data["caption"]))
+        end
+    end
+
+    return collated
+end
+
+function Pandoc(doc)
+    local table_fields = {}
+
+    for _, block in ipairs(doc.blocks) do
+        if block.t == "Table" then
+            local fields = extractCommandFields(block)
+            if fields ~= nil then
+                table.insert(table_fields, {caption = pandoc.utils.stringify(block.caption.long), fields = fields})
+            end
+        end
+    end
+
+    print(string.format("Extracted data from %d tables", #table_fields))
+    print("Collating tables")
+
+    local collated = collateCommandsAndResponses(table_fields)
+
+    -- Overwrite the entire document with a single code block containing the JSON
+    local json_string = pandoc.json.encode(collated)
+    return pandoc.Pandoc({pandoc.CodeBlock(json_string)})
+end


### PR DESCRIPTION
Example output:

```
{
  "CertifyCreation": {
    "command": {
      "command_fields": [
        {
          "description": "TPM_ST_SESSIONS",
          "name": "tag",
          "type": "TPMI_ST_COMMAND_TAG"
        },
        {
          "description": "",
          "name": "commandSize",
          "type": "UINT32"
        },
        {
          "description": "TPM_CC_CertifyCreation",
          "name": "commandCode",
          "type": "TPM_CC"
        }
      ],
      "handle_fields": [
        {
          "description": "handle of the key that will sign the attestation blockAuth Index: 1Auth Role: USER",
          "name": "@signHandle",
          "type": "TPMI_DH_OBJECT+"
        },
        {
          "description": "the object associated with the creation dataAuth Index: None",
          "name": "objectHandle",
          "type": "TPMI_DH_OBJECT"
        }
      ],
      "parameter_fields": [
        {
          "description": "user-provided qualifying data",
          "name": "qualifyingData",
          "type": "TPM2B_DATA"
        },
        {
          "description": "hash of the creation data produced by TPM2_Create() or TPM2_CreatePrimary()",
          "name": "creationHash",
          "type": "TPM2B_DIGEST"
        },
        {
          "description": "signing scheme to use if the scheme for signHandle is TPM_ALG_NULL",
          "name": "inScheme",
          "type": "TPMT_SIG_SCHEME+"
        },
        {
          "description": "ticket produced by TPM2_Create() or TPM2_CreatePrimary()",
          "name": "creationTicket",
          "type": "TPMT_TK_CREATION"
        }
      ]
    },
    "response": {
      "command_fields": [
        {
          "description": "see @sec:response-values",
          "name": "tag",
          "type": "TPM_ST"
        },
        {
          "description": "",
          "name": "responseSize",
          "type": "UINT32"
        },
        {
          "description": "",
          "name": "responseCode",
          "type": "TPM_RC"
        }
      ],
      "handle_fields": {},
      "parameter_fields": [
        {
          "description": "the structure that was signed",
          "name": "certifyInfo",
          "type": "TPM2B_ATTEST"
        },
        {
          "description": "the signature over certifyInfo",
          "name": "signature",
          "type": "TPMT_SIGNATURE"
        }
      ]
    }
  }
}
```